### PR TITLE
Fix typos in manual_jp.md

### DIFF
--- a/docs/manual_jp.md
+++ b/docs/manual_jp.md
@@ -221,8 +221,8 @@ optimize:
   - **upper** - ハイパーパラメータ最大値を設定します。
   - **initial** - ハイパーパラメータの初期値を設定します。
   - **step**  - ハイパーパラメータの分解能を設定します(最適化アルゴリズムがgridの場合は必ず指定してください。)。
-  - **log** - 対数設定用の項目です(最適化アルゴリズムがgridの場合は必ず指定してください。)。
-  - **base** - 対数設定用の項目です(最適化アルゴリズムがgridの場合は必ず指定してください。)。
+  - **log** - 対数スケールで探索します。値はtrue/falseで指定して下さい。最適化アルゴリズムがgridの場合は必ず指定してください。
+  - **base** - 底数を指定します。最適化アルゴリズムがgridの場合は必ず指定してください。
   - **comment** - 自由記述欄。
 
 
@@ -452,7 +452,7 @@ def func(x1, x2):
 
 これを、aiaccelで最適化させるには次のように変更します。
 ```python
-from aiaccel.util import opt
+from aiaccel.util import aiaccel
 
 def func(p):
     x1 = p["x1"]
@@ -462,7 +462,7 @@ def func(p):
 
 if __name__ == "__main__":
     
-    run = opt.Run()
+    run = aiaccel.Run()
     run.execute_and_report(func)
 ```
 


### PR DESCRIPTION
1. Fix comments on grid search items "log" and "base
2. Fix typos in sample code

---
1. グリッド検索項目「log」「base」のコメント修正
2. サンプルコードの誤字修正