### PR TITLE
Feature/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The software currently supports five optimization algorithms: random search, gri
 # Installation
 The software can be installed using `pip`.
 ~~~
-pip install git+https://github.com/aistairc/aiaccel.git
+> pip install git+https://github.com/aistairc/aiaccel.git
 ~~~
 
 # Getting started
@@ -24,9 +24,8 @@ An example for optimizeing a simple function (i.e., sphere function) on a local 
 
 0. (Optional) Install [Virtualenv](https://virtualenv.pypa.io/en/latest/) and create a virtual environment. 
     ~~~bash
-    > pip install virtualenv
-    > virtualenv venv
-    > source venv/bin/activate
+    > python3 -m venv work
+    > source work/bin/activate
     ~~~
 
 1. Install `aiaccel`
@@ -54,7 +53,7 @@ An example for optimizeing a simple function (i.e., sphere function) on a local 
     > python -m aiaccel.start --config config.yaml
     ~~~
 
-    Tips: You can clean the workspace directory using `--clean`.
+    Tips: You can start after cleaning the workspace directory using `--clean`.
     ~~~bash
     > python -m aiaccel.start --config config.yaml --clean
     ~~~
@@ -71,7 +70,7 @@ An example for optimizeing a simple function (i.e., sphere function) on a local 
 
 5. If you want to change configurations, edit `config.yaml`.
     ~~~bash
-    vi config.yaml
+    > vi config.yaml
     ~~~
 
 ## Running on ABCI
@@ -79,13 +78,13 @@ This tutorial describes how to run examples/sphere on ABCI.
 
 1. First, setup python environment following [the ABCI Users Guide](https://docs.abci.ai/en/python/):
     ~~~bash
-    module load gcc/11.2.0
-    module load python/3.8/3.8.13
-    python3 -m venv work
-    source work/bin/activate
+    > module load gcc/11.2.0
+    > module load python/3.8/3.8.13
+    > python3 -m venv work
+    > source work/bin/activate
     ~~~
 
-2. Prepare the workspace by following Steps 1 to 4 in [Running on a local computer](https://github.com/aistairc/aiaccel#Running-on-a-local-computer).
+2. Prepare the workspace by following Steps 1 and 2 in [Running on a local computer](https://github.com/aistairc/aiaccel#Running-on-a-local-computer).
 
 3. Please confirm the configuration file before running master.
     ```yaml
@@ -99,8 +98,7 @@ This tutorial describes how to run examples/sphere on ABCI.
     > python -m aiaccel.start --config config.yaml
     ~~~
 
-5. The other processes are same with [sphere tutorial on local computer](https://github.com/aistairc/aiaccel#sphere-tutorial-on-local-computer) from 6 to 10.
-If you want to check the running jobs, please refer the [ABCI User Guide](https://docs.abci.ai/ja/).
+5. If you want to check the running jobs, please refer the [ABCI User Guide](https://docs.abci.ai/en/job-execution/#show-the-status-of-batch-jobs).
 
 # Acknowledgment
 * Part of this software was developed in a project commissioned by the New Energy and Industrial Technology Deve

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The software currently supports five optimization algorithms: random search, gri
 
 # Installation
 The software can be installed using `pip`.
-~~~
+~~~bash
 > pip install git+https://github.com/aistairc/aiaccel.git
 ~~~
 
@@ -94,7 +94,7 @@ This tutorial describes how to run examples/sphere on ABCI.
     ```
 
 4. Run on an (interactive) job
-    ~~~
+    ~~~bash
     > python -m aiaccel.start --config config.yaml
     ~~~
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -9,7 +9,7 @@
 # インストール
 本ソフトウェアは下記コマンドでインストールできます。
 ~~~bash
-pip install git+https://github.com/aistairc/aiaccel.git
+> pip install git+https://github.com/aistairc/aiaccel.git
 ~~~
 
 # 実行例
@@ -17,14 +17,13 @@ pip install git+https://github.com/aistairc/aiaccel.git
 
 0. (オプション) Virtualenvをインストールし、仮想環境を作成します。
     ~~~bash
-    > pip install virtualenv
-    > virtualenv venv
-    > source venv/bin/activate
+    > python3 -m venv work
+    > source work/bin/activate
     ~~~
 
 1. `aiaccel`をインストールします
     ~~~bash
-    pip install git+https://github.com/aistairc/aiaccel.git 
+    > pip install git+https://github.com/aistairc/aiaccel.git
     ~~~
 
 
@@ -65,32 +64,33 @@ pip install git+https://github.com/aistairc/aiaccel.git
 
 5. 設定を変更したい場合は、config.yamlファイルを編集してください。
     ~~~bash
-    vi config.yaml
+    > vi config.yaml
     ~~~
 
 ## ABCI上で実行する
 1. まず、[ABCIユーザーズガイド](https://docs.abci.ai/ja/python)に従って、pythonの環境を構築してください。
     ~~~bash
-    module load python/3.8/3.8.13
-    python3 -m venv work
-    source work/bin/activate
+    > module load gcc/11.2.0
+    > module load python/3.8/3.8.13
+    > python3 -m venv work
+    > source work/bin/activate
     ~~~
 
-2. config.yamlのresourceをABCIに変更します。
+2. ワークスペースを用意します．ここからの作業は、[ローカル環境で実行する場合](https://github.com/aistairc/aiaccel/blob/main/README_JP.md#%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E7%92%B0%E5%A2%83%E3%81%A7%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88)の1,2と同じです。
+
+3. config.yamlのresourceをABCIに変更します。
     ```yaml
     resource:
         type: "ABCI"
         num_node: 4
     ```
 
-3. ワークスペースを用意します．ここからの作業は、[ローカル環境で実行する場合](https://github.com/aistairc/aiaccel/blob/main/README_JP.md#%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E7%92%B0%E5%A2%83%E3%81%A7%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88)の2および3と同じです。
-
 4. 実行
     ~~~bash
     > python -m aiaccel.start --config config.yaml
     ~~~
 
-5. 実行中のジョブを確認したい場合は、[ABCIユーザーズガイド](https://docs.abci.ai/ja/)を参照してください。
+5. 実行中のジョブを確認したい場合は、[ABCIユーザーズガイド](https://docs.abci.ai/ja/job-execution/#show-the-status-of-batch-jobs)を参照してください。
 
 
 # 開発中の機能wdについて


### PR DESCRIPTION
Reflect issue #24
- both README.md and README_JP.md
   - Use `venv` instead of `virtualenv`
   - Add `module load gcc` before `module load python/3.8/3.8.13`
   - Add `>` to some commands that don't have `>` in top
   - Correct "Steps 1 to 2" instead of "Steps 1 to 4" because it is unnecesary for preparing the workspace that "3. Run the parameter optimization" and "4. Wait for the program to finish and check the optimization results."

- README.md
   - Update the "--clean" option description
      - start -> start after cleaning
   - correct the link to ABCI user guide from Japanese to English.
   - "The other processes are same with [sphere tutorial on local computer](https://github.com/aistairc/aiaccel#sphere-tutorial-on-local-computer) from 6 to 10." is unneccesary
   - Some space for command don't have `bash`
- README_JP.md
   -  Steps 2 and 3 in "Running on ABCI" are reversed.