### PR TITLE
fix codestyle test

### DIFF
--- a/aiaccel/master/abstract_master.py
+++ b/aiaccel/master/abstract_master.py
@@ -342,7 +342,7 @@ class AbstractMaster(AbstractModule):
         Returns:
             bool
         """
-        if(
+        if (
             not self.optimizer_proc.poll() is None or
             not self.scheduler_proc.poll() is None
         ):

--- a/aiaccel/optimizer/tpe/search.py
+++ b/aiaccel/optimizer/tpe/search.py
@@ -244,7 +244,7 @@ class TpeSearchOptimizer(AbstractOptimizer):
                 # debug
                 print('Running trial does not match any running files.')
                 print('\ttrial params: ', t.params)
-                raise()
+                raise ()
 
 
 def create_distributions(

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pytest
 pytest-arraydiff==0.2
 pytest-astropy==0.4.0
 pytest-cov==2.10.1
+flake8==4.0.1
 pytest-flake8==1.0.6
 pytest-pycodestyle==2.2.0
 pytest-subprocess==1.0.0


### PR DESCRIPTION
Fix for `Pycodestyle Test` and `Flack8 Test`

- For `Pycodestyle Test`
   - Add white space
- For  `Flack8 Test`
   - Specify 'flake8' version as 4.0.1 (Update to flake8 occurred on 8/1 and the class 'ConfigFileFinder' became unusable)