### PR TITLE
Fix TPE resumtion test

### DIFF
--- a/tests/resumption/resumption_test.py
+++ b/tests/resumption/resumption_test.py
@@ -28,6 +28,7 @@ class ResumptionTest(IntegrationTest):
         wait_alive(work_dir)
         base_clean_work_dir(data_dir, work_dir)
 
+        time.sleep(10)
         config_file = data_dir.joinpath(
             'config_{}_resumption.json'.format(self.search_algorithm)
         )
@@ -40,6 +41,7 @@ class ResumptionTest(IntegrationTest):
         print('resumed steps finished')
         wait_alive(work_dir)
 
+        time.sleep(10)
         config_file = data_dir.joinpath(
             'config_{}.json'.format(self.search_algorithm)
         )
@@ -54,6 +56,7 @@ class ResumptionTest(IntegrationTest):
             dict_resume
         ]
         run_master(commandline_args, work_dir)
+        wait_alive(work_dir)    #
         final_result_resumption = get_final_result(work_dir)
         print('resumption steps finished', final_result_resumption)
         assert final_result_at_one_time == final_result_resumption

--- a/tests/resumption/resumption_test.py
+++ b/tests/resumption/resumption_test.py
@@ -20,28 +20,29 @@ class ResumptionTest(IntegrationTest):
         commandline_args = [
             "start.py",
             "--config",
-            format(config_file)
+            format(config_file),
+            "--clean"
         ]
+        delete_alive(work_dir)
         run_master(commandline_args, work_dir)
         final_result_at_one_time = get_final_result(work_dir)
         print('at one time', final_result_at_one_time)
         wait_alive(work_dir)
+        delete_alive(work_dir)
         base_clean_work_dir(data_dir, work_dir)
-
-        time.sleep(10)
         config_file = data_dir.joinpath(
             'config_{}_resumption.json'.format(self.search_algorithm)
         )
         commandline_args = [
             "start.py",
             "--config",
-            format(config_file)
+            format(config_file),
+            "--clean"
         ]
         run_master(commandline_args, work_dir)
         print('resumed steps finished')
         wait_alive(work_dir)
-
-        time.sleep(10)
+        delete_alive(work_dir)
         config_file = data_dir.joinpath(
             'config_{}.json'.format(self.search_algorithm)
         )
@@ -57,6 +58,7 @@ class ResumptionTest(IntegrationTest):
         ]
         run_master(commandline_args, work_dir)
         wait_alive(work_dir)    #
+        delete_alive(work_dir)
         final_result_resumption = get_final_result(work_dir)
         print('resumption steps finished', final_result_resumption)
         assert final_result_at_one_time == final_result_resumption
@@ -94,7 +96,18 @@ def wait_alive(work_dir):
                 break
         if not alive:
             break
-        time.sleep(0.1)
+        time.sleep(1.0)
+
+
+def delete_alive(work_dir):
+    alive_files = [
+        work_dir.joinpath(aiaccel.dict_alive, aiaccel.alive_master),
+        work_dir.joinpath(aiaccel.dict_alive, aiaccel.alive_optimizer),
+        work_dir.joinpath(aiaccel.dict_alive, aiaccel.alive_scheduler)
+    ]
+    for alive_file in alive_files:
+        if alive_file.exists():
+            alive_file.unlink()
 
 
 def base_clean_work_dir(data_dir, work_dir):

--- a/tests/resumption/sphere/test_sphere_tpe_resumption.py
+++ b/tests/resumption/sphere/test_sphere_tpe_resumption.py
@@ -2,8 +2,8 @@ from tests.resumption.resumption_test import ResumptionTest
 import aiaccel
 
 
-class TestSphereRandomResumption(ResumptionTest):
+class TestSphereTpeResumption(ResumptionTest):
 
     @classmethod
     def setup_class(cls):
-        cls.search_algorithm = aiaccel.search_algorithm_random
+        cls.search_algorithm = aiaccel.search_algorithm_tpe


### PR DESCRIPTION
1. The TPE resume test was equivalent to the random search resume test and the TPE test was not possible.
With modification, the TPE resume test was enabled.

2. Fixed a problem that caused the TPE resume test to be Failed.