### PR TITLE
Fix CI Unit test error

### DIFF
--- a/tests/unit/master_test/test_abci_master.py
+++ b/tests/unit/master_test/test_abci_master.py
@@ -73,15 +73,7 @@ class TestAbciMaster(BaseTest):
         with patch.object(sys, 'argv', commandline_args):
             options = Arguments()
             master = AbciMaster(options)
-        master.storage.alive.init_alive()
         master.pre_process()
-        # alive_files = get_dict_files(work_dir.joinpath('alive'), '*.yml')
-
-        # for f in alive_files:
-        #     f.unlink()
-
-        # self.master.scheduler_proc.wait()
-        # self.master.optimizer_proc.wait()
         assert type(master.runner_files) is list
 
     def test_get_stats(

--- a/tests/unit/master_test/test_abstract_master.py
+++ b/tests/unit/master_test/test_abstract_master.py
@@ -56,10 +56,7 @@ class TestAbstractMaster(BaseTest):
 
         with patch.object(sys, 'argv', commandline_args):
             options = Arguments()
-            # master = create_master(options['config'])(options)
             master = AbstractMaster(options)
-            # master = start.Master()
-        # master = AbstractMaster(options)
         work_dir.joinpath(aiaccel.dict_runner).rmdir()
         loop = asyncio.get_event_loop()
         gather = asyncio.gather(
@@ -67,8 +64,6 @@ class TestAbstractMaster(BaseTest):
             delay_make_directory(1, work_dir.joinpath(aiaccel.dict_runner))
         )
         loop.run_until_complete(gather)
-
-        master.storage.alive.init_alive()
 
         if master.scheduler_proc is not None:
             master.scheduler_proc.wait()
@@ -78,7 +73,7 @@ class TestAbstractMaster(BaseTest):
 
         master.worker_o.kill()
         master.worker_s.kill()
-        master.storage.alive.init_alive()
+        
 
     def test_pre_process_2(
         self,
@@ -98,6 +93,7 @@ class TestAbstractMaster(BaseTest):
         with patch.object(sys, 'argv', commandline_args):
             options = Arguments()
             master = AbstractMaster(options)
+        master.storage.alive.init_alive()
         master.start_optimizer()
         master.start_scheduler()
 
@@ -141,7 +137,6 @@ class TestAbstractMaster(BaseTest):
         # master.th_scheduler.abort()
         master.worker_o.kill()
         master.worker_s.kill()
-        master.storage.alive.init_alive()
 
     def test_pre_process_3(
         self,
@@ -161,6 +156,7 @@ class TestAbstractMaster(BaseTest):
             'process_name': 'master'
         }
         master = AbstractMaster(options)
+        master.storage.alive.init_alive()
         setup_hp_finished(10)
         assert master.pre_process() is None
 

--- a/tests/unit/master_test/test_abstract_master.py
+++ b/tests/unit/master_test/test_abstract_master.py
@@ -68,7 +68,7 @@ class TestAbstractMaster(BaseTest):
         )
         loop.run_until_complete(gather)
 
-        # master.storage.alive.init_alive()
+        master.storage.alive.init_alive()
 
         if master.scheduler_proc is not None:
             master.scheduler_proc.wait()


### PR DESCRIPTION
mainブランチ [7f46e35](https://github.com/aistairc/aiaccel/commit/7f46e3533774a8bb2f7cdc47fb04f6cd06306cd6)で発生したCIテストエラーを解消．
データベースの初帰化が，テストコードとmasterのpreprocessとで2回実施されていたため，テストコード側での初帰化を削除しました．