### PR TITLE
Feature/fix cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,18 @@ An example for optimizeing a simple function (i.e., sphere function) on a local 
 
 3. Run the parameter optimization
     ~~~bash
-    > python -m aiaccel.start --config config.yaml
+    > aiaccel-start --config config.yaml
+    ~~~
+
+    or
+
+    ~~~bash
+    > python -m aiaccel.cli.start --config config.yaml
     ~~~
 
     Tips: You can start after cleaning the workspace directory using `--clean`.
     ~~~bash
-    > python -m aiaccel.start --config config.yaml --clean
+    > aiaccel-start --config config.yaml --clean
     ~~~
 
 4. Wait for the program to finish and check the optimization results.
@@ -95,7 +101,7 @@ This tutorial describes how to run examples/sphere on ABCI.
 
 4. Run on an (interactive) job
     ~~~bash
-    > python -m aiaccel.start --config config.yaml
+    > aiaccel-start --config config.yaml
     ~~~
 
 5. If you want to check the running jobs, please refer the [ABCI User Guide](https://docs.abci.ai/en/job-execution/#show-the-status-of-batch-jobs).
@@ -104,17 +110,17 @@ This tutorial describes how to run examples/sphere on ABCI.
 ## Other
 - Check the progress
     ~~~bash
-    > python -m aiaccel.view --config config.yaml
+    > aiaccel-view --config config.yaml
     ~~~
 
 - Display simple graphs
     ~~~bash
-    > python -m aiaccel.plot --config config.yaml
+    > aiaccel-plot --config config.yaml
     ~~~
 
 - Output results to workspace/results.csv.
     ~~~bash
-    > python -m aiaccel.report --config config.yaml
+    > aiaccel-report --config config.yaml
     ~~~
 
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -44,12 +44,18 @@
 
 3. パラメータ最適化を実行します。
     ~~~bash
-    > python -m aiaccel.start --config config.yaml
+    > aiaccel-start --config config.yaml
+    ~~~
+
+    または、
+
+    ~~~bash
+    > python -m aiaccel.cli.start --config config.yaml
     ~~~
 
     Tips: ワークスペースは `--clean` を付加することで実行前に初期化できます。
     ~~~bash
-    > python -m aiaccel.start --config config.yaml --clean
+    > aiaccel-start --config config.yaml --clean
     ~~~
 
 4. 結果を確認する。
@@ -87,7 +93,7 @@
 
 4. 実行
     ~~~bash
-    > python -m aiaccel.start --config config.yaml
+    > aiaccel-start --config config.yaml
     ~~~
 
 5. 実行中のジョブを確認したい場合は、[ABCIユーザーズガイド](https://docs.abci.ai/ja/job-execution/#show-the-status-of-batch-jobs)を参照してください。
@@ -96,17 +102,17 @@
 ## その他
 - 処理の進捗を確認
     ~~~bash
-    > python -m aiaccel.view --config config.yaml
+    > aiaccel-view --config config.yaml
     ~~~
 
 - 簡易グラフを表示
     ~~~bash
-    > python -m aiaccel.plot --config config.yaml
+    > aiaccel-plot --config config.yaml
     ~~~
 
 - workspace/results.csvに結果を出力
     ~~~bash
-    > python -m aiaccel.report --config config.yaml
+    > aiaccel-report --config config.yaml
     ~~~
 
 # 開発中の機能wdについて

--- a/aiaccel/cli/report.py
+++ b/aiaccel/cli/report.py
@@ -2,7 +2,8 @@ from aiaccel.argument import Arguments
 from aiaccel.util.report import CreationReaport
 import sys
 
-if __name__ == "__main__":
+
+def main():
     options = Arguments()
     if "config" not in options.keys():
         print("Specify the config file path with the --config option.")
@@ -10,3 +11,7 @@ if __name__ == "__main__":
 
     report = CreationReaport(options)
     report.create()
+
+
+if __name__ == "__main__":
+    main()

--- a/aiaccel/cli/stop.py
+++ b/aiaccel/cli/stop.py
@@ -1,6 +1,5 @@
 from aiaccel.argument import Arguments
 from aiaccel.config import Config
-from aiaccel.workspace import Workspace
 from aiaccel.storage.storage import Storage
 from pathlib import Path
 

--- a/aiaccel/cli/stop.py
+++ b/aiaccel/cli/stop.py
@@ -2,6 +2,7 @@ from aiaccel.argument import Arguments
 from aiaccel.config import Config
 from aiaccel.workspace import Workspace
 from aiaccel.storage.storage import Storage
+from pathlib import Path
 
 
 def main() -> None:  # pragma: no cover
@@ -13,13 +14,12 @@ def main() -> None:  # pragma: no cover
     config = Config(options['config'])
     workspace = config.workspace.get()
 
-    ws = Workspace(workspace)
-    if ws.exists() is False:
+    if Path(workspace).exists() is False:
         print(f"{workspace} is not found.")
         return
 
     storage = Storage(
-        workspace,
+        Path(workspace).resolve(),
         fsmode=options['fs'],
         config_path=options['config']
     )

--- a/docs/manual_jp.md
+++ b/docs/manual_jp.md
@@ -529,7 +529,7 @@ export PYTHONPATH=$AIACCELPATH:$AIACCELPATH/lib
 ## 6 最適化実行
 プロジェクトフォルダに移動し、次のコマンドを実行します。
 ```bash
-> python -m aiaccel.start --config config.yaml
+> aiaccel-start --config config.yaml
 ```
 
 - ご注意
@@ -546,18 +546,18 @@ export PYTHONPATH=$AIACCELPATH:$AIACCELPATH/lib
 
 `start`コマンドの後に、追加オプションを指定できます。
 ```bash
-> python -m aiaccel.start
+> aiaccel-start
 ```
 - --clean : workspaceが既に存在する場合、最適化実行前にworkspaceを削除します。
 - --resume : workspaceが既に存在する場合、保存データが存在するトライアルを指定することで、指定のトライアルから再開することができます。
 
 ##### 例
 ```bash
-python -m aiaccel.start --config config.yaml --clean
+> aiaccel-start --config config.yaml --clean
 ```
 
 ```bash
-python -m aiaccel.start --config config.yaml --resume 5
+> aiaccel-start --config config.yaml --resume 5
 ```
 
 <hr>
@@ -596,12 +596,12 @@ ABCI:
 # 7 進捗の可視化について
 ##### 全結果の表示
 ```bash
-> python -m aiaccel.view --config config.yaml
+> aiaccel-view --config config.yaml
 ```
 
 ##### 簡易フラグの表示
 ```bash
-> python -m aiaccel.graph --config config.yaml
+> aiaccel-graph --config config.yaml
 ``` -->
 
 

--- a/examples/resnet50_cifar10/README_JP.md
+++ b/examples/resnet50_cifar10/README_JP.md
@@ -149,10 +149,10 @@ source ../../../../resnet50sample_env/bin/activate
 <br>
 
 ## 3. 動作説明
-- optとpytorchが動作する環境が必要です。
+- aiaccelとpytorchが動作する環境が必要です。
 
     - ABCIにおけるpytorch導入手順(出典:https://docs.abci.ai/ja/apps/pytorch/)
-        - optの仮想環境作成・activate後、下記コマンドを実行してください。
+        - aiaccelの仮想環境作成・activate後、下記コマンドを実行してください。
 
             ```bash
             pip3 install --upgrade pip setuptools
@@ -180,10 +180,10 @@ source ../../../../resnet50sample_env/bin/activate
     python setup_dataset.py
     ```
 
-- 上記準備が完了したら、下記コマンドでoptを起動してください。
+- 上記準備が完了したら、下記コマンドでaiaccelを起動してください。
 
     ```bash
-    python -m aiaccel.start --config config.yaml --clean
+    aiaccel-start --config config.yaml --clean
     ```
 
 <br>

--- a/experimental/USAGE_JP.md
+++ b/experimental/USAGE_JP.md
@@ -136,7 +136,7 @@ qrsh -g gaa*****(ご自身のグループ名) -l rt_C.small=1 -l h_rt=1:00:00
 ```
 source ~/aiaccel/experimental/tools/make_aiaccel_env.source
 cd ~/aiaccel/experimental/examples/config/aiaccel-test/readme_jp-sample-local/
-python -m aiaccel.start --config config.yml --clean
+aiaccel-start --config config.yml --clean
 ```
 と実行します。
 

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,14 @@ setup(
     install_requires=requirements,
     zip_safe=False,
     setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-cov"]
+    tests_require=["pytest", "pytest-cov"],
+    entry_points={
+        'console_scripts': [
+            'aiaccel-plot=aiaccel.cli.plot:main',
+            'aiaccel-report=aiaccel.cli.report:main',
+            'aiaccel-start=aiaccel.cli.start:main',
+            'aiaccel-stop=aiaccel.cli.stop:main',
+            'aiaccel-view=aiaccel.cli.view:main',
+        ],
+    },
 )


### PR DESCRIPTION
Fix aiaccel execution command to `aiaccel-xxxx` (issue #66)

---

改修内容
- setup.py に entry_points を追加
  - entry_points は関数を呼び出す仕様なので、その都合で report.py に `def main()` を追加
- README.md 等に記載のコマンドを修正
- (stop.py で TypeError が発生していたため、修正)