### PR TITLE
Fix duplicate output of sceduler and optimizer

### DIFF
--- a/aiaccel/master/abstract.py
+++ b/aiaccel/master/abstract.py
@@ -58,10 +58,8 @@ class AbstractMaster(AbstractModule):
 
         # optimizer
         self.o = create_optimizer(options['config'])(options)
-        self.o.__init__(self.options)
         # scheduler
         self.s = create_scheduler(options['config'])(options)
-        self.s.__init__(self.options)
 
         self.worker_o = multiprocessing.Process(target=self.o.start)
         self.worker_s = multiprocessing.Process(target=self.s.start)


### PR DESCRIPTION
Fix duplicate output of sceduler and optimizer caused by duplicate logger settings.

---

改修内容
・`self.o = create_optimizer(options['config'])(options)`で1回、`self.o.__init__(self.options)`で2回のlogger設定が行われていたので、`self.o.__init__(self.options)`を削除しました。（schedulerも同様）

https://github.com/aistairc/aiaccel/blob/7c5fa8c543d3cdeb1ffedd1c8c29a67fb421d834/aiaccel/master/abstract.py#L59-L64