### PR TITLE
Fix initial random paramater

### DIFF
--- a/aiaccel/optimizer/abstract.py
+++ b/aiaccel/optimizer/abstract.py
@@ -103,14 +103,6 @@ class AbstractOptimizer(AbstractModule):
                 None if any parameters are already created.
         """
         if self.num_of_generated_parameter == 0:
-
-            for hp in self.params.hps.values():
-                if hp.initial is not None:
-                    break
-            else:
-                # all hp.initial is None
-                return None
-
             sample = self.params.sample(initial=True)
             new_params = []
 

--- a/aiaccel/optimizer/abstract.py
+++ b/aiaccel/optimizer/abstract.py
@@ -103,6 +103,14 @@ class AbstractOptimizer(AbstractModule):
                 None if any parameters are already created.
         """
         if self.num_of_generated_parameter == 0:
+
+            for hp in self.params.hps.values():
+                if hp.initial is not None:
+                    break
+            else:
+                # all hp.initial is None
+                return None
+
             sample = self.params.sample(initial=True)
             new_params = []
 

--- a/aiaccel/optimizer/nelder_mead/sampler.py
+++ b/aiaccel/optimizer/nelder_mead/sampler.py
@@ -88,22 +88,7 @@ class NelderMead(object):
         self.coef = coef
         self.n_dim = len(self.bdrys)
 
-        self.y = self._create_initial_values()
-        if initial_parameters is not None:
-            for dp in initial_parameters:
-                if (
-                    type(dp['value']) is int or
-                    type(dp['value']) is float
-                ):
-                    dp['value'] = [dp['value']]
-
-                if type(dp['value']) is not list:
-                    raise TypeError('Default parameter should be set as list.')
-
-                ind = [p.name for p in self.params].index(dp['parameter_name'])
-
-                for i in range(len(dp['value'])):
-                    self.y[i][ind] = dp['value'][i]
+        self.y = self._create_initial_values(initial_parameters)
 
         self.f = []
         self.yc = None
@@ -134,11 +119,34 @@ class NelderMead(object):
         for y in self.y:
             self._add_executing(y)
 
-    def _create_initial_values(self) -> list:
-        initial_values = [
-            [random.random() * (b[1] - b[0]) + b[0] for b in self.bdrys]
-            for _ in range(self.n_dim + 1)
-        ]
+    def _create_initial_values(self, initial_parameters) -> list:
+        initial_values = []
+        for num_of_initials in range(self.n_dim + 1):
+            initial_value = []
+            for dim in range(len(self.bdrys)):
+                if initial_parameters is not None:
+                    if (
+                        type(initial_parameters[dim]['value']) is int or
+                        type(initial_parameters[dim]['value']) is float
+                    ):
+                        initial_parameters[dim]['value'] = [initial_parameters[dim]['value']]
+
+                    if type(initial_parameters[dim]['value']) is not list:
+                        raise TypeError('Default parameter should be set as list.')
+
+                    if num_of_initials < len(initial_parameters[dim]['value']):
+                        initial_value.append(initial_parameters[dim]['value'][num_of_initials])
+                    else:
+                        initial_value.append(
+                            np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
+                        )
+
+                else:
+                    initial_value.append(
+                        np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
+                        )
+            initial_values.append(initial_value)
+
         return np.array(initial_values)
 
     def _add_executing(

--- a/aiaccel/optimizer/nelder_mead/sampler.py
+++ b/aiaccel/optimizer/nelder_mead/sampler.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Union
 import copy
 import logging
 import numpy as np
-import random
 
 STATES = [
     'WaitInitialize',

--- a/aiaccel/optimizer/nelder_mead/sampler.py
+++ b/aiaccel/optimizer/nelder_mead/sampler.py
@@ -119,34 +119,31 @@ class NelderMead(object):
             self._add_executing(y)
 
     def _create_initial_values(self, initial_parameters) -> list:
-        initial_values = []
-        for num_of_initials in range(self.n_dim + 1):
-            initial_value = []
-            for dim in range(len(self.bdrys)):
-                if initial_parameters is not None:
-                    if (
-                        type(initial_parameters[dim]['value']) is int or
-                        type(initial_parameters[dim]['value']) is float
-                    ):
-                        initial_parameters[dim]['value'] = [initial_parameters[dim]['value']]
-
-                    if type(initial_parameters[dim]['value']) is not list:
-                        raise TypeError('Default parameter should be set as list.')
-
-                    if num_of_initials < len(initial_parameters[dim]['value']):
-                        initial_value.append(initial_parameters[dim]['value'][num_of_initials])
-                    else:
-                        initial_value.append(
-                            np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
-                        )
-
-                else:
-                    initial_value.append(
-                        np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
-                        )
-            initial_values.append(initial_value)
+        initial_values = [
+            [self._create_initial_value(initial_parameters, dim, num_of_initials) for dim in range(len(self.bdrys))]
+            for num_of_initials in range(self.n_dim + 1)
+        ]
 
         return np.array(initial_values)
+
+    def _create_initial_value(self, initial_parameters, dim, num_of_initials):
+        if initial_parameters is not None:
+            if (
+                type(initial_parameters[dim]['value']) is int or
+                type(initial_parameters[dim]['value']) is float
+            ):
+                initial_parameters[dim]['value'] = [initial_parameters[dim]['value']]
+
+            if type(initial_parameters[dim]['value']) is not list:
+                raise TypeError('Default parameter should be set as list.')
+
+            if num_of_initials < len(initial_parameters[dim]['value']):
+                return initial_parameters[dim]['value'][num_of_initials]
+            else:
+                return np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
+
+        else:
+            return np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
 
     def _add_executing(
         self, y: np.ndarray,

--- a/aiaccel/optimizer/nelder_mead/sampler.py
+++ b/aiaccel/optimizer/nelder_mead/sampler.py
@@ -120,7 +120,7 @@ class NelderMead(object):
 
     def _create_initial_values(self, initial_parameters) -> list:
         initial_values = [
-            [self._create_initial_value(initial_parameters, dim, num_of_initials) for dim in range(len(self.bdrys))]
+            [self._create_initial_value(initial_parameters, dim, num_of_initials) for dim in range(len(self.params))]
             for num_of_initials in range(self.n_dim + 1)
         ]
 
@@ -140,10 +140,10 @@ class NelderMead(object):
             if num_of_initials < len(initial_parameters[dim]['value']):
                 return initial_parameters[dim]['value'][num_of_initials]
             else:
-                return np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
+                return self.params[dim].sample()['value']
 
         else:
-            return np.random.random() * (self.bdrys[dim][1] - self.bdrys[dim][0]) + self.bdrys[dim][0]
+            return self.params[dim].sample()['value']
 
     def _add_executing(
         self, y: np.ndarray,

--- a/aiaccel/optimizer/tpe/search.py
+++ b/aiaccel/optimizer/tpe/search.py
@@ -72,6 +72,9 @@ class TpeOptimizer(AbstractOptimizer):
             bool: Is a current trial startup trial or not.
         """
         n_startup_trials = self.study.sampler.get_startup_trials()
+        # If initial exists, the output of n_startup_trials is reduced
+        # by the number of initials before the original n_startup_trials,
+        # so the number of initials needs to be added to the right side.
         return self.num_of_generated_parameter < n_startup_trials + self.initial_count
 
     def generate_parameter(self, number: Optional[int] = 1) -> None:

--- a/aiaccel/optimizer/tpe/search.py
+++ b/aiaccel/optimizer/tpe/search.py
@@ -24,6 +24,7 @@ class TpeOptimizer(AbstractOptimizer):
         self.distributions = None
         self.trial_pool = {}
         self.randseed = self.config.randseed.get()
+        self.initial_count = 0
 
     def pre_process(self) -> None:
         """Pre-Procedure before executing optimize processes.
@@ -71,7 +72,7 @@ class TpeOptimizer(AbstractOptimizer):
             bool: Is a current trial startup trial or not.
         """
         n_startup_trials = self.study.sampler.get_startup_trials()
-        return self.num_of_generated_parameter < n_startup_trials
+        return self.num_of_generated_parameter < n_startup_trials + self.initial_count
 
     def generate_parameter(self, number: Optional[int] = 1) -> None:
         """Generate parameters.
@@ -87,16 +88,8 @@ class TpeOptimizer(AbstractOptimizer):
         if initial_parameter is not None:
             trial_id = self.register_ready(initial_parameter)
             self.parameter_pool[trial_id] = initial_parameter['parameters']
-            enqueue_trial = {}
-
-            for param in self.parameter_pool[trial_id]:
-                enqueue_trial[param['parameter_name']] = param['value']
-
-            self.study.enqueue_trial(enqueue_trial)
             self.logger.info(f'newly added name: {trial_id} to parameter_pool')
-            t = self.study.ask(self.distributions)
-            self.trial_pool[trial_id] = t
-            self.num_of_generated_parameter += 1
+
             number -= 1
 
         for _ in range(number):
@@ -128,6 +121,38 @@ class TpeOptimizer(AbstractOptimizer):
             self.logger.info(f'newly added name: {trial_id} to parameter_pool')
 
             self._serialize()
+
+    def generate_initial_parameter(self):
+
+        if self.num_of_generated_parameter == 0:
+            enqueue_trial = {}
+            for hp in self.params.hps.values():
+                if hp.initial is not None:
+                    enqueue_trial[hp.name] = hp.initial
+
+            # all hp.initial is None
+            if len(enqueue_trial) == 0:
+                return None
+
+            self.study.enqueue_trial(enqueue_trial)
+            t = self.study.ask(self.distributions)
+            self.initial_count += 1
+            self.trial_pool[self.initial_count] = t
+
+            new_params = []
+
+            for name, value in t.params.items():
+                new_param = {
+                    'parameter_name': name,
+                    'type': self.params.hps[name].type,
+                    'value': value
+                }
+                new_params.append(new_param)
+
+            self.num_of_generated_parameter += 1
+            return {'parameters': new_params}
+
+        return None
 
     def create_study(self) -> None:
         """Create the optuna.study object and store it.

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -193,7 +193,7 @@ class HyperParameter(object):
         if initial and self.initial is not None:
             value = self.initial
         elif self.type == 'INT':
-            value = np.random.randrange(self.lower, self.upper)
+            value = np.random.randint(self.lower, self.upper)
         elif self.type == 'FLOAT':
             value = np.random.uniform(self.lower, self.upper)
         elif self.type == 'CATEGORICAL':

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import List, Tuple, Union
 import aiaccel
 import logging
-import random
 import numpy as np
 
 

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Union
 import aiaccel
 import logging
 import random
+import numpy as np
 
 
 def get_best_parameter(files: List[Path], goal: str, dict_lock: Path) ->\
@@ -193,13 +194,13 @@ class HyperParameter(object):
         if initial and self.initial is not None:
             value = self.initial
         elif self.type == 'INT':
-            value = random.randrange(self.lower, self.upper)
+            value = np.random.randrange(self.lower, self.upper)
         elif self.type == 'FLOAT':
-            value = random.uniform(self.lower, self.upper)
+            value = np.random.uniform(self.lower, self.upper)
         elif self.type == 'CATEGORICAL':
-            value = random.choice(self.choices)
+            value = np.random.choice(self.choices)
         elif self.type == 'ORDINAL':
-            value = random.choice(self.sequence)
+            value = np.random.choice(self.sequence)
         else:
             raise TypeError(
                 f'Invalid hyper parameter type: {self.type}')


### PR DESCRIPTION
Fixed the random part values of random, TPE, and NM to become the same value. (fix Issue #73)

---

- 改修内容
    - aiaccel 側の乱数生成方法を `random` -> `numpy.random` に変更
    - TPE
        - 乱数生成を全て optuna 側で行うように変更
            - optunaを使う都合で `generate_initial_parameter`を`tpe/search.py` 独自のものに変更
        - (初期点の並列数判定を行う箇所に `self.initial_count` を追加)
    - NM
        - 初期点の生成方法を`generate_initial_parameter`の結果反映と、乱数生成を平行して行うように変更