### PR TITLE
Fix generate_initial_parameter()

### DIFF
--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -355,7 +355,7 @@ class Config:
         """
         self.config_path = Path(config_path).resolve()
         if not self.config_path.exists():
-            logger.erro(f"config file: {config_path} doesn't exist.")
+            logger.error(f"config file: {config_path} doesn't exist.")
 
         self.config = load_config(self.config_path)
         self.define_items(self.config, warn)

--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -165,4 +165,4 @@ class GridOptimizer(AbstractOptimizer):
                 "Initial values cannot be specified for grid search."
                 "The set initial value has been invalidated."
             )
-        return None
+        return self.generate_parameter()

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -34,7 +34,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
             initial_parameters=initial_parameter
         )
 
-        return
+        return self.generate_parameter()
 
     def check_result(self) -> None:
         pass

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -76,4 +76,4 @@ class SobolOptimizer(AbstractOptimizer):
                 "Initial values cannot be specified for sobol."
                 "The set initial value has been invalidated."
             )
-        return None
+        return self.generate_parameter()


### PR DESCRIPTION
generate_initial_parameter()でNoneが返った場合，次の状態に遷移しなくなります．

次の3つのoptimizerの`generate_initial_parameter()`の戻り値を変更しました．
- sobol
- grid
- nelder mead

sobolとgridは初期値設定が無効なため, `generate_initial_parameter()`内で`generate_parameter()`の結果を返すようにしています．

nelder meadは初期値生成の処理が他のoptimizerとは大きく異なり，`generate_initial_parameter()`の戻り値が本来不要だったようですが，こちらも同じく`generate_initial_parameter()`内で`generate_parameter()`を呼出すように変更しています．


