### PR TITLE
Delete unnecessary processes from TPE and NM

### DIFF
--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -53,25 +53,22 @@ class NelderMeadOptimizer(AbstractOptimizer):
         Returns:
             list[dict]: Results per trial.
         """
-        results = self.storage.result.get_result_trial_id_list()
         nm_results = []
         for p in self.get_ready_parameters():
             try:
-                int(p['vertex_id'])
+                index = int(p['vertex_id'])
             except ValueError:
                 continue
             except KeyError:
                 continue
 
-            if int(p['vertex_id']) in results:
-                index = p['vertex_id']
-            else:
-                continue
+            result_content = self.storage.result.get_any_trial_objective(index)
 
-            result_content = self.storage.get_hp_dict(trial_id_str=index)
-            nm_result = copy.copy(p)
-            nm_result['result'] = result_content['result']
-            nm_results.append(nm_result)
+            if result_content is not None:
+                nm_result = copy.copy(p)
+                nm_result['result'] = result_content
+                nm_results.append(nm_result)
+
         return nm_results
 
     def _add_result(self, nm_results: list) -> None:


### PR DESCRIPTION
1. optunaのTPEの結果と、aiaccelのTPEの結果が揃わなくなっていたので、修正しました。

　原因は、 is_startup_trialsの返り値でした。
https://github.com/aistairc/aiaccel/blob/63233c01527472b3d1a885b32a00ca06dd402178/aiaccel/optimizer/tpe_optimizer.py#L74-L84
　 is_startup_trials はTPEの初期点(optunaのデフォルトで10点)の計算中かどうかを返す関数で、
　これを用いて初期点の並列計算を制御しています。
　不要な `self.initial_count` が加算されており、これによって余分に1回 `study.ask()` が呼び出され、
　乱数seedがずれたため、optunaの結果と揃わなくなっていました。

　（`self.initial_count` が存在していた経緯としては、
　元々 `aiaccel/optimizer/tpe/search.py` には、initial反映を行うコード中に
　余分な `self.num_of_generated_parameter += 1`が含まれており、
　これに気づかずに initial が存在する際にはreturn文の右辺の加算が必要だと判断し、
　`self.initial_count`を追加しました。。
　どこかのリファクタリングの過程で余分な `self.num_of_generated_parameter += 1` が削除され、
　今回の現象が露見したものと推測します。）

2. TPE, NM内の `storage.get_hp_dict()` を削除し、`storage.result.get_any_trial_objective()` に置き換えました。
それに伴い、コードの修正・リファクタリングを行いました。