### PR TITLE
Move get_grid_options() in parameter.py to grid_optimizer.py

### DIFF
--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -1,11 +1,55 @@
 import math
 from functools import reduce
 from operator import mul
-from typing import List, Union
+from typing import List, Tuple, Union
 
 from aiaccel.config import Config
 from aiaccel.optimizer.abstract_optimizer import AbstractOptimizer
-from aiaccel.parameter import HyperParameter, get_grid_options
+from aiaccel.parameter import HyperParameter
+
+
+def get_grid_options(
+    parameter_name: str,
+    config: Config
+) -> Tuple[Union[int, None], bool, Union[int, None]]:
+
+    """Get options about grid search.
+
+    Args:
+        parameter_name (str): A parameter name to get its options.
+        config (ConfileWrapper): A config object.
+
+    Returns:
+        Tuple[Union[int, None], bool, Union[int, None]]: The first one is a
+            base of logarithm parameter. The second one is logarithm parameter
+            or not. The third one is a step of the grid.
+
+    Raises:
+        KeyError: Causes when step is not specified.
+    """
+    base = None
+    log = False
+    step = None
+
+    grid_options = config.hyperparameters.get()
+
+    for g in grid_options:
+        if g['name'] == parameter_name:
+            if 'step' not in g.keys():
+                raise KeyError(f'No grid option `step` for parameter: {parameter_name}')
+            if 'log' not in g.keys():
+                raise KeyError(f'No grid option `log` for parameter: {parameter_name}')
+            if 'base' not in g.keys():
+                raise KeyError(f'No grid option `base` for parameter: {parameter_name}')
+
+            step = float(g['step'])
+            log = bool(g['log'])
+            if log:
+                base = int(g['base'])
+
+            return base, log, step
+
+    raise KeyError(f'Invalid parameter name: {parameter_name}')
 
 
 def generate_grid_points(p: HyperParameter, config: Config) -> dict:

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -5,7 +5,6 @@ from typing import List, Tuple, Union
 import numpy as np
 
 import aiaccel
-from aiaccel.config import Config
 from aiaccel.util.filesystem import load_yaml
 
 
@@ -49,48 +48,6 @@ def get_best_parameter(files: List[Path], goal: str, dict_lock: Path) ->\
             raise ValueError(f'Invalid goal: {goal}.')
 
     return best, best_file
-
-
-def get_grid_options(
-    parameter_name: str,
-    config: Config
-) -> Tuple[Union[int, None], bool, Union[int, None]]:
-
-    """Get options about grid search.
-
-    Args:
-        parameter_name (str): A parameter name to get its options.
-        config (ConfileWrapper): A config object.
-
-    Returns:
-        Tuple[Union[int, None], bool, Union[int, None]]: The first one is a
-            base of logarithm parameter. The second one is logarithm parameter
-            or not. The third one is a step of the grid.
-
-    Raises:
-        KeyError: Causes when step is not specified.
-    """
-    base = None
-    log = False
-    step = None
-
-    grid_options = config.hyperparameters.get()
-
-    for g in grid_options:
-        if g['name'] == parameter_name:
-            if 'step' in g.keys():
-                step = float(g['step'])
-            else:
-                step = None
-            log = bool(g['log'])
-            if log:
-                base = int(g['base'])
-            break
-
-    if step is None:
-        raise KeyError(f'No grid option for parameter: {parameter_name}')
-    else:
-        return base, log, step
 
 
 def get_type(parameter: dict) -> str:

--- a/tests/test_data/config_grid.json
+++ b/tests/test_data/config_grid.json
@@ -33,6 +33,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -41,6 +42,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -49,6 +51,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -57,6 +60,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -65,6 +69,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -73,6 +78,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -81,6 +87,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -89,6 +96,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -97,6 +105,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       }

--- a/tests/test_data/config_grid_resumption.json
+++ b/tests/test_data/config_grid_resumption.json
@@ -33,6 +33,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -41,6 +42,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -49,6 +51,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -57,6 +60,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -65,6 +69,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0
       },
@@ -72,6 +77,7 @@
         "name": "x7",
         "type": "uniform_float",
         "step": 1.0,
+        "base": 10,
         "log": false,
         "lower": -5.0,
         "upper": 5.0
@@ -80,6 +86,7 @@
         "name": "x8",
         "type": "uniform_float",
         "step": 1.0,
+        "base": 10,
         "log": false,
         "lower": -5.0,
         "upper": 5.0
@@ -88,6 +95,7 @@
         "name": "x9",
         "type": "uniform_float",
         "step": 1.0,
+        "base": 10,
         "log": false,
         "lower": -5.0,
         "upper": 5.0
@@ -96,6 +104,7 @@
         "name": "x10",
         "type": "uniform_float",
         "step": 1.0,
+        "base": 10,
         "log": false,
         "lower": -5.0,
         "upper": 5.0

--- a/tests/test_data/grid_config.json
+++ b/tests/test_data/grid_config.json
@@ -33,6 +33,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 2.98
@@ -42,6 +43,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 3.62
@@ -51,6 +53,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 0.90
@@ -60,6 +63,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 1.99
@@ -69,6 +73,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": -2.78
@@ -78,6 +83,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 1.00
@@ -87,6 +93,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 4.97
@@ -96,6 +103,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 1.98
@@ -105,6 +113,7 @@
         "type": "uniform_float",
         "step": 1.0,
         "log": false,
+        "base": 10,
         "lower": -5.0,
         "upper": 5.0,
         "initial": 4.03

--- a/tests/unit/optimizer_test/test_grid_search.py
+++ b/tests/unit/optimizer_test/test_grid_search.py
@@ -1,10 +1,28 @@
 import functools
+from pathlib import Path
 
+from aiaccel.config import Config
 from aiaccel.optimizer.grid_optimizer import (GridOptimizer,
-                                              generate_grid_points)
+                                              generate_grid_points,
+                                              get_grid_options)
 from aiaccel.parameter import HyperParameter, load_parameter
-
 from tests.base_test import BaseTest
+
+
+def test_get_grid_options():
+    test_data_dir = Path(__file__).resolve().parent.parent.parent.joinpath('test_data')
+    grid_config_json = test_data_dir.joinpath('grid_config.json')
+    config_grid = Config(grid_config_json)
+
+    base, log, step = get_grid_options('x1', config_grid)
+    assert base == 10
+    assert log
+    assert step == 0.1
+    try:
+        _, _, _ = get_grid_options('invalid', config_grid)
+        assert False
+    except KeyError:
+        assert True
 
 
 def test_generate_grid_points(grid_load_test_config):

--- a/tests/unit/test_parameter.py
+++ b/tests/unit/test_parameter.py
@@ -1,8 +1,6 @@
 import aiaccel
-from aiaccel.parameter import (get_best_parameter, get_grid_options, get_type,
-                               load_parameter)
+from aiaccel.parameter import get_best_parameter, get_type, load_parameter
 from aiaccel.util.filesystem import create_yaml
-
 from tests.base_test import BaseTest
 
 
@@ -55,21 +53,6 @@ class TestParameter(BaseTest):
             )
             assert False
         except ValueError:
-            assert True
-
-    def test_get_grid_options(self):
-        # base, log, step = get_grid_options('x1', self.config)
-        # コンフィグファイルの読取り形式変更改修に伴いテストコードも変更(荒本)
-        base, log, step = get_grid_options('x1', self.config_grid)
-        assert base == 10
-        assert log
-        assert step == 0.1
-        try:
-            # _, _, _ = get_grid_options('invalid', self.config)
-            # コンフィグファイルの読取り形式変更改修に伴いテストコードも変更(荒本)
-            _, _, _ = get_grid_options('invalid', self.config_grid)
-            assert False
-        except KeyError:
             assert True
 
     def test_get_type(self):


### PR DESCRIPTION
1. aiaccel/parameter.pyの`get_grid_options()`を，aiaccel/optimizer/grid_optimzier.pyへ移管しました．
2. `get_grid_options()`で，コンフィグファイルのハイパラ設定項目の`step`の有無をチェックしていますが，`log`, `base`も同じようにチェックするように変更しました.（`log`, `base`も後段の処理で使用するため)
3. grid searchのテストで使用するコンフィグファイルに'base'の項目が抜けていたため，追加しました．

2, 3はissues #102 に未記入の項目ですが，改修箇所が同じであるのと，比較的小規模の改修であることから，#102として対応しています．

close #102 