### PR TITLE
fix tpe generate initial parameter

### DIFF
--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -53,25 +53,22 @@ class NelderMeadOptimizer(AbstractOptimizer):
         Returns:
             list[dict]: Results per trial.
         """
-        results = self.storage.result.get_result_trial_id_list()
         nm_results = []
         for p in self.get_ready_parameters():
             try:
-                int(p['vertex_id'])
+                index = int(p['vertex_id'])
             except ValueError:
                 continue
             except KeyError:
                 continue
 
-            if int(p['vertex_id']) in results:
-                index = p['vertex_id']
-            else:
-                continue
+            result_content = self.storage.result.get_any_trial_objective(index)
 
-            result_content = self.storage.get_hp_dict(trial_id_str=index)
-            nm_result = copy.copy(p)
-            nm_result['result'] = result_content['result']
-            nm_results.append(nm_result)
+            if result_content is not None:
+                nm_result = copy.copy(p)
+                nm_result['result'] = result_content
+                nm_results.append(nm_result)
+
         return nm_results
 
     def _add_result(self, nm_results: list) -> None:

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -115,9 +115,6 @@ class TpeOptimizer(AbstractOptimizer):
 
     def generate_initial_parameter(self):
 
-        if self.num_of_generated_parameter > 0:
-            return None
-
         enqueue_trial = {}
         for hp in self.params.hps.values():
             if hp.initial is not None:
@@ -125,7 +122,7 @@ class TpeOptimizer(AbstractOptimizer):
 
         # all hp.initial is None
         if len(enqueue_trial) == 0:
-            return None
+            return self.generate_parameter()
 
         self.study.enqueue_trial(enqueue_trial)
         trial = self.study.ask(self.distributions)

--- a/aiaccel/storage/hp.py
+++ b/aiaccel/storage/hp.py
@@ -52,7 +52,7 @@ class Hp(Abstract):
                     HpTable(
                         trial_id=trial_id,
                         param_name=d['parameter_name'],
-                        param_value=d['value'],
+                        param_value=str(d['value']),
                         param_type=d['type']
                     ) for d in params
                 ]


### PR DESCRIPTION
1.、initilalが存在しない時、tpeの最適化が進まない現象を修正しました。

　initilalが存在しない場合、 `generate_initial_parameter` が `None` を返し、無限ループが発生していました。
　（tpeの場合、optuna側にinitialの値を生成させる必要があるため、個別に `generate_initial_parameter` が必要です。）

　現行の `abstract_optimizer.py` に合わせて、initial が存在しない場合には `self.generate_parameter()` を返すように変更しました。

　（initilalが存在しない場合のテストも必要と感じたため、#105 に合わせて追加予定です。）

2. optuna の計算結果と小数点以下第13位付近から結果が合わなくなっていた現象を修正しました。

　データベースに出力された点の値を格納する際に、
　d['value']の型をfloatのまま渡すと、HpTableでは value をstrとして受け取る設定になっているため、
　データベース側で切り捨てが発生した後にstrへの変換が発生する様子です。

データベースに値を渡している箇所(d['value'] が float)
https://github.com/aistairc/aiaccel/blob/f18ec0a1611a7c52d43db2de5acb8de5647151a9/aiaccel/storage/hp.py#L51-L60
値を受け取っているデータベースの定義(str)
https://github.com/aistairc/aiaccel/blob/b34a3e84559a8387c0aa2bbb4a057dd29c2a3caa/aiaccel/storage/model.py#L36

　値の切り捨ての影響で計算結果もずれていました。

　なので、データベースに渡す前に `str` に変換する形に修正しました。
