### PR TITLE
Add check_error() in abstruct_optimizer.py

### DIFF
--- a/aiaccel/optimizer/abstract_optimizer.py
+++ b/aiaccel/optimizer/abstract_optimizer.py
@@ -245,5 +245,5 @@ class AbstractOptimizer(AbstractModule):
         for trial_id in error_trial_ids:
             error_message = self.storage.error.get_any_trial_error(trial_id=trial_id)
             self.logger.error(error_message)
-        
+
         return False

--- a/aiaccel/optimizer/abstract_optimizer.py
+++ b/aiaccel/optimizer/abstract_optimizer.py
@@ -236,3 +236,14 @@ class AbstractOptimizer(AbstractModule):
             self.options['resume'] > 0
         ):
             self._deserialize(self.options['resume'])
+
+    def check_error(self) -> bool:
+        error_trial_ids = self.storage.error.get_error_trial_id()
+        if len(error_trial_ids) == 0:
+            return True
+
+        for trial_id in error_trial_ids:
+            error_message = self.storage.error.get_any_trial_error(trial_id=trial_id)
+            self.logger.error(error_message)
+        
+        return False

--- a/tests/unit/optimizer_test/test_abstract_optimizer.py
+++ b/tests/unit/optimizer_test/test_abstract_optimizer.py
@@ -67,3 +67,10 @@ class TestAbstractOptimizer(BaseTest):
             with patch.object(self.optimizer, 'generate_parameter', return_value=param):
                 with patch.object(self.optimizer, '_serialize', return_value=None):
                     assert self.optimizer.inner_loop_main_process() is True
+
+    def test_check_error(self):
+        self.optimizer.storage.error.all_delete()
+        assert self.optimizer.check_error() is True
+
+        self.optimizer.storage.error.set_any_trial_error(trial_id=0, error_message="test_error")
+        assert self.optimizer.check_error() is False


### PR DESCRIPTION
1. abstruct_optimzier.pyに`check_error()`を追加しました．
DBに保存されたエラーメッセージ(user.pyで発生した場合に保存される)を参照し，エラーがあればFalseを返します．
`start.py`で`check_error()`の戻り値を判定，Falseならば最適化処理を終了します．

https://github.com/aistairc/aiaccel/blob/875c40c3d0edf058fe529cb6e390f21ac62981e3/aiaccel/cli/start.py#L73

close #98 