### PR TITLE
Fix issue#126

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -65,6 +65,7 @@ jobs:
           pytest -v tests/newly_test/no_initial/benchmark/test_benchmark_nelder_mead_no_initial.py
           pytest -v tests/newly_test/additional_resumption/benchmark/test_benchmark_tpe_resumption.py
           pytest -v tests/newly_test/additional_resumption/benchmark/test_benchmark_nelder_mead_resumption.py
+          pytest -v tests/newly_test/random_generation/benchmark/test_benchmark_random_generation.py
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -155,7 +155,7 @@ class HyperParameter(object):
         elif self.type.lower() == 'int':
             value = rng.randint(self.lower, self.upper)
         elif self.type.lower() == 'float':
-            value = rng.uniform([self.lower, self.upper])[0]
+            value = rng.uniform(self.lower, self.upper)
         elif self.type.lower() == 'categorical':
             value = rng.choice(self.choices)
         elif self.type.lower() == 'ordinal':

--- a/tests/newly_test/random_generation/benchmark/test_benchmark_random_generation.py
+++ b/tests/newly_test/random_generation/benchmark/test_benchmark_random_generation.py
@@ -1,0 +1,7 @@
+
+
+from tests.newly_test.random_generation.random_generation_test import RandomGenerationTest
+
+
+class TestBenchmarkRandomGeneration(RandomGenerationTest):
+    pass

--- a/tests/newly_test/random_generation/benchmark/test_data/config_nelder-mead.yaml
+++ b/tests/newly_test/random_generation/benchmark/test_data/config_nelder-mead.yaml
@@ -1,0 +1,112 @@
+generic:
+  workspace: "/tmp/work"
+  job_command: "python user.py"
+  batch_job_timeout: 600
+  sleep_time: 0
+
+resource:
+  type: "local"
+  num_node: 10
+
+ABCI:
+  group: "[group]"
+  job_script_preamble: "./job_script_preamble.sh"
+  job_execution_options: ""
+  runner_search_pattern:
+
+optimize:
+  search_algorithm: "aiaccel.optimizer.NelderMeadOptimizer"
+  goal: "minimize"
+  trial_number: 10
+  rand_seed: 42
+  parameters:
+    -
+      name: "x1"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x2"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x3"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x4"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x5"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x6"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x7"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x8"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x9"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+
+job_setting:
+  cancel_retry: 3
+  cancel_timeout: 60
+  expire_retry: 3
+  expire_timeout: 60
+  finished_retry: 3
+  finished_timeout: 60
+  job_loop_duration: 0.5
+  job_retry: 2
+  job_timeout: 60
+  kill_retry: 3
+  kill_timeout: 60
+  result_retry: 1
+  runner_retry: 3
+  runner_timeout: 60
+  running_retry: 3
+  running_timeout: 60
+  init_fail_count: 100
+  name_length: 6
+  random_scheduling: false
+  #random_scheduling: true
+
+# sleep_time: 0
+  # master: 1
+  # scheduler: 1
+  # optimizer: 1
+
+logger:
+  file:
+    master: "master.log"
+    optimizer: "optimizer.log"
+    scheduler: "scheduler.log"
+  log_level:
+    master: "DEBUG"
+    optimizer: "DEBUG"
+    scheduler: "DEBUG"
+  stream_level:
+    master: "DEBUG"
+    optimizer: "CRITICAL"
+    scheduler: "CRITICAL"
+
+verification:
+  is_verified: false
+  condition: []

--- a/tests/newly_test/random_generation/benchmark/test_data/config_random.yaml
+++ b/tests/newly_test/random_generation/benchmark/test_data/config_random.yaml
@@ -1,0 +1,112 @@
+generic:
+  workspace: "/tmp/work"
+  job_command: "python user.py"
+  batch_job_timeout: 600
+  sleep_time: 0
+
+resource:
+  type: "local"
+  num_node: 10
+
+ABCI:
+  group: "[group]"
+  job_script_preamble: "./job_script_preamble.sh"
+  job_execution_options: ""
+  runner_search_pattern:
+
+optimize:
+  search_algorithm: "aiaccel.optimizer.RandomOptimizer"
+  goal: "minimize"
+  trial_number: 10
+  rand_seed: 42
+  parameters:
+    -
+      name: "x1"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x2"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x3"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x4"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x5"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x6"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x7"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x8"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x9"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+
+job_setting:
+  cancel_retry: 3
+  cancel_timeout: 60
+  expire_retry: 3
+  expire_timeout: 60
+  finished_retry: 3
+  finished_timeout: 60
+  job_loop_duration: 0.5
+  job_retry: 2
+  job_timeout: 60
+  kill_retry: 3
+  kill_timeout: 60
+  result_retry: 1
+  runner_retry: 3
+  runner_timeout: 60
+  running_retry: 3
+  running_timeout: 60
+  init_fail_count: 100
+  name_length: 6
+  random_scheduling: false
+  #random_scheduling: true
+
+# sleep_time: 0
+  # master: 0
+  # scheduler: 0
+  # optimizer: 0
+
+logger:
+  file:
+    master: "master.log"
+    optimizer: "optimizer.log"
+    scheduler: "scheduler.log"
+  log_level:
+    master: "DEBUG"
+    optimizer: "DEBUG"
+    scheduler: "DEBUG"
+  stream_level:
+    master: "DEBUG"
+    optimizer: "CRITICAL"
+    scheduler: "CRITICAL"
+
+verification:
+  is_verified: false
+  condition: []

--- a/tests/newly_test/random_generation/benchmark/test_data/config_tpe.yaml
+++ b/tests/newly_test/random_generation/benchmark/test_data/config_tpe.yaml
@@ -1,0 +1,112 @@
+generic:
+  workspace: "/tmp/work"
+  job_command: "python user.py"
+  batch_job_timeout: 600
+  sleep_time: 0
+
+resource:
+  type: "local"
+  num_node: 10
+
+ABCI:
+  group: "[group]"
+  job_script_preamble: "./job_script_preamble.sh"
+  job_execution_options: ""
+  runner_search_pattern:
+
+optimize:
+  search_algorithm: "aiaccel.optimizer.TpeOptimizer"
+  goal: "minimize"
+  trial_number: 10
+  rand_seed: 42
+  parameters:
+    -
+      name: "x1"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x2"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x3"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x4"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x5"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x6"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x7"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x8"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+    -
+      name: "x9"
+      type: "uniform_float"
+      lower: 0.0
+      upper: 5.0
+
+job_setting:
+  cancel_retry: 3
+  cancel_timeout: 60
+  expire_retry: 3
+  expire_timeout: 60
+  finished_retry: 3
+  finished_timeout: 60
+  job_loop_duration: 0.5
+  job_retry: 2
+  job_timeout: 60
+  kill_retry: 3
+  kill_timeout: 60
+  result_retry: 1
+  runner_retry: 3
+  runner_timeout: 60
+  running_retry: 3
+  running_timeout: 60
+  init_fail_count: 100
+  name_length: 6
+  random_scheduling: false
+  #random_scheduling: true
+
+# sleep_time: 0
+  # master: 0
+  # scheduler: 0
+  # optimizer: 0
+
+logger:
+  file:
+    master: "master.log"
+    optimizer: "optimizer.log"
+    scheduler: "scheduler.log"
+  log_level:
+    master: "DEBUG"
+    optimizer: "DEBUG"
+    scheduler: "DEBUG"
+  stream_level:
+    master: "DEBUG"
+    optimizer: "CRITICAL"
+    scheduler: "CRITICAL"
+
+verification:
+  is_verified: false
+  condition: []

--- a/tests/newly_test/random_generation/benchmark/test_data/user.py
+++ b/tests/newly_test/random_generation/benchmark/test_data/user.py
@@ -1,0 +1,15 @@
+from aiaccel.util import aiaccel
+import numpy as np
+
+
+def main(p):
+    x = np.array([p["x1"], p["x2"], p["x3"], p["x4"], p["x5"], p["x6"], p["x7"], p["x8"], p["x9"]])
+    y = np.sum(x ** 2)
+
+    return y
+
+
+if __name__ == "__main__":
+
+    run = aiaccel.Run()
+    run.execute_and_report(main)

--- a/tests/newly_test/random_generation/random_generation_test.py
+++ b/tests/newly_test/random_generation/random_generation_test.py
@@ -1,0 +1,54 @@
+# Test random generation of random, tpe and neler-mead optimizer.
+
+import subprocess
+from pathlib import Path
+
+from aiaccel.config import Config
+from aiaccel.storage.storage import Storage
+
+from tests.base_test import BaseTest
+
+
+class RandomGenerationTest(BaseTest):
+    search_algorithm = None
+
+    def test_run(self, cd_work, data_dir, work_dir):
+        test_data_dir = Path(__file__).resolve().parent.joinpath('benchmark', 'test_data')
+
+        # random execution
+        config_file = test_data_dir.joinpath('config_random.yaml')
+        config = Config(config_file)
+
+        storage = Storage(ws=Path(config.workspace.get()))
+        subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean'],
+                         cwd=test_data_dir).wait()
+        final_result_random = self.get_final_result(storage)
+        print('random', final_result_random)
+
+        # tpe execution
+        config_file = test_data_dir.joinpath('config_tpe.yaml')
+        config = Config(config_file)
+
+        storage = Storage(ws=Path(config.workspace.get()))
+        subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean'],
+                         cwd=test_data_dir).wait()
+        final_result_tpe = self.get_final_result(storage)
+        print('tpe', final_result_tpe)
+
+        assert final_result_random == final_result_tpe
+
+        # nelder-mead execution
+        config_file = test_data_dir.joinpath('config_nelder-mead.yaml')
+        config = Config(config_file)
+
+        storage = Storage(ws=Path(config.workspace.get()))
+        subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean'],
+                         cwd=test_data_dir).wait()
+        final_result_neldermead = self.get_final_result(storage)
+        print('nelder-mead', final_result_neldermead)
+
+        assert final_result_random == final_result_neldermead
+
+    def get_final_result(self, storage):
+        data = storage.result.get_all_result()
+        return [d.objective for d in data]


### PR DESCRIPTION
https://github.com/aistairc/aiaccel/blob/280a401b8499bbf734df4a650539af5a1f78e85e/aiaccel/parameter.py#L158

この記述だと、`rng.uniform([self.lower, self.upper])`の部分で乱数が複数生成され、TPE(optuna)の生成する乱数とrandom, NelderMead(aiaccel)との乱数生成にずれが生じます。

`value = rng.uniform(self.lower, self.upper)`
に修正し、余計な乱数生成が発生しないようにすると、各optimizerのrandomの出力値が揃うようになりました。

また、newly_test に random, TPE, NelderMead の乱数生成部分を比較するテストを追加しました。
TPEのランダムで生成する初期点の数(10点)に合わせて、パラメータ数を9にしてNelderMeadの初期点も10で揃えています。
random, TPE, NelderMead の初期点10点の計算結果を比較しています。

close #126 