### PR TITLE
Add a scramble option for sobol optimizer

### DIFF
--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -330,6 +330,7 @@ _DEFAULT_HYPERPARAMETERS = []
 _DEFAULT_IS_VERIFIED = False
 _DEFAULT_VERIFI_CONDITION = []
 _DEFAULT_RANDOM_SCHESULING = True
+_DEFAULT_SOBOL_SCRAMBLE = True
 _RESOURCE_TYPES = ['abci', 'local']
 _GOALS = ['minimize', 'maximize']
 
@@ -737,6 +738,15 @@ class Config:
             warning=False,
             group="logger",
             keys=("stream_level", "scheduler")
+        )
+
+        self.sobol_scramble = ConfigEntry(
+            config=config,
+            type=[bool],
+            default=_DEFAULT_SOBOL_SCRAMBLE,
+            warning=False,
+            group="optimize",
+            keys=("sobol_scramble")
         )
 
         # === verification ===

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -32,10 +32,13 @@ class SobolOptimizer(AbstractOptimizer):
 
         finished = self.storage.trial.get_finished()
         self.generate_index = len(finished)
-        self.sampler = qmc.Sobol(d=len(self.params.get_parameter_list()), scramble=False, seed=self._rng)
 
-        if self.generate_index is not None and self.generate_index > 0:
-            self.sampler.fast_forward(self.generate_index)
+        if self.options['resume'] is None or self.options['resume'] <= 0:
+            self.sampler = qmc.Sobol(
+                d=len(self.params.get_parameter_list()),
+                scramble=self.config.sobol_scramble.get(),
+                seed=self._rng
+            )
 
     def generate_parameter(self) -> None:
         """Generate parameters.


### PR DESCRIPTION
Sobolオプティマイザに scramble オプションを設定する修正です．config.py へのオプション追加と初期値の設定（ランダム的な振る舞いをする初期値へ変更），それに伴う sobol_optimizer.py の変更です．

### 余談
scipy.stas.qmc.Sobol は seed に numpy.random.Generator 型の引数を与えると再現性が失われるため，resume する際は _deserialize のコードに任せて初期化をしないようにしました．

```
from scipy.stats import qmc
import numpy as np

seed = 0

# Generate two values
rng = np.random.RandomState(seed)
sampler = qmc.Sobol(d=1, scramble=True, seed=rng)
l1 = []
l1.append(sampler.random())
l1.append(sampler.random())

# Generate one value and Resume qmc.Sobol
rng = np.random.RandomState(seed)
sampler = qmc.Sobol(d=1, scramble=True, seed=rng)
l2 = []
l2.append(sampler.random())
sampler = qmc.Sobol(d=1, scramble=True, seed=rng)
l2.append(sampler.random())
```
上記のコードで l1 と l2 は異なる値を持ちます．正確には l1[0] == l2[0] ですが， l1[1] != l2[1] です．

rng をシリアライズしても qmc.Sobol をコールすると再現性が失われます．

上記コードの sampler は rng という変数を持ちジェネレータを保持しているのでこれをいじっても良いのですが，後々を考えるとシンプルなコードの方がベターだと思います．