### PR TITLE
Feature/fix typo in examples and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This tutorial describes how to run examples/sphere on ABCI.
     > module load gcc/11.2.0
     > module load python/3.8/3.8.13
     > python3 -m venv optenv
-    > source work/bin/activate
+    > source optenv/bin/activate
     ~~~
 
 2. Prepare the workspace by following Steps 1 and 2 in [Running on a local computer](https://github.com/aistairc/aiaccel#Running-on-a-local-computer).

--- a/README_JP.md
+++ b/README_JP.md
@@ -81,7 +81,7 @@
     > module load gcc/11.2.0
     > module load python/3.8/3.8.13
     > python3 -m venv optenv
-    > source work/bin/activate
+    > source optenv/bin/activate
     ~~~
 
 2. ワークスペースを用意します．ここからの作業は、[ローカル環境で実行する場合](https://github.com/aistairc/aiaccel/blob/main/README_JP.md#%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E7%92%B0%E5%A2%83%E3%81%A7%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88)の1,2と同じです。

--- a/docs/source/user_guide/basic_usage.md
+++ b/docs/source/user_guide/basic_usage.md
@@ -11,7 +11,7 @@ ABCIのセットアップは下記資料を参考ください。
 venv環境での使用を推奨いたします。このチュートリアルはvenv環境で動作させることを前提としています。
 
 ~~~bash
-python -m venv optenv
+python3 -m venv optenv
 ~~~
 
 ここでは仮想環境の名前を「optenv」とし、以後も当仮想環境を「optenv」と表記します。
@@ -144,23 +144,23 @@ ABCI:
 
 ```yaml
 optimize:
-search_algorithm: "nelder-mead"
-goal: "minimize"
-trial_number: 30
-rand_seed: 42
-parameters:
-    -
-    name: "x1"
-    type: "uniform_float"
-    lower: 0.0
-    upper: 5.0
-    initial: 1.0
-    -
-    name: "x2"
-    type: "uniform_float"
-    lower: 0.0
-    upper: 5.0
-    initial: 1.0
+    search_algorithm: "aiaccel.optimizer.NelderMeadOptimizer"
+    goal: "minimize"
+    trial_number: 30
+    rand_seed: 42
+    parameters:
+        -
+            name: "x1"
+            type: "uniform_float"
+            lower: 0.0
+            upper: 5.0
+            initial: 1.0
+        -
+            name: "x2"
+            type: "uniform_float"
+            lower: 0.0
+            upper: 5.0
+            initial: 1.0
 ```
 
 - **search_algorithm** - 最適化アルゴリズムを指定します。
@@ -388,7 +388,7 @@ ABCI:
     job_execution_options: ""
 
 optimize:
-    search_algorithm: "nelder-mead"
+    search_algorithm: "aiaccel.optimizer.NelderMeadOptimizer"
     goal: "minimize"
     trial_number: 30
     rand_seed: 42
@@ -398,16 +398,17 @@ optimize:
             type: "uniform_float"
             lower: 0.0
             upper: 5.0
-            initial: 1.0
+            initial: [0.0, 5.0, 3.0]
         -
             name: "x2"
             type: "uniform_float"
             lower: 0.0
             upper: 5.0
-            initial: 1.0
+            initial: [2.0, 4.0, 1.0]
 ```
 
 3. ユーザープログラムの作成
+
 最適化対象の処理を作成します。ここでは、作成済みモデルをaiaccelで最適化するための変更方法を記述します。
 
 次の関数を最適化させる場合の例を示します。
@@ -437,6 +438,7 @@ optimize:
 ```
 
 4. Wrapperの作成
+
 必要に応じてwrapperプログラムを作成します。aiaccelはユーザープログラムのwrapperを作成するためのAPIを提供します。
 
 **サンプル**
@@ -468,6 +470,7 @@ aiaccelでwrapperプログラムを最適化させる場合はコンフィグフ
 ```
 
 5. job_script_preamble.shの作成
+
 `job_script_preamble.sh` は、ABCIにジョブを投入するためのバッチファイルのベースファイルです。
 このファイルには事前設定を記述します。ここに記述した設定が全てのジョブに適用されます。
 
@@ -493,9 +496,10 @@ aiaccelでwrapperプログラムを最適化させる場合はコンフィグフ
 ~~~
 
 6. 最適化実行
+
 プロジェクトフォルダに移動し、次のコマンドを実行します。
 ~~~bash
-python -m aiaccel.start --config config.yaml
+python -m aiaccel.cli.start --config config.yaml
 ~~~
 
 ```{note}
@@ -509,7 +513,7 @@ python -m aiaccel.start --config config.yaml
 `start` コマンドの後に、追加オプションを指定できます。
 
 ~~~bash
-python -m aiaccel.start
+python -m aiaccel.cli.start
 ~~~
 
 - --clean : workspaceが既に存在する場合、最適化実行前にworkspaceを削除します。
@@ -517,7 +521,7 @@ python -m aiaccel.start
 
 ### 例
 ~~~bash
-python -m aiaccel.start --config config.yaml --clean
+python -m aiaccel.cli.start --config config.yaml --clean
 ~~~
 
 ### ローカル環境での実行方法

--- a/examples/sphere/config.yaml
+++ b/examples/sphere/config.yaml
@@ -7,7 +7,7 @@ generic:
 
 resource:
   type: "local"
-  #type: "local"
+  #type: "ABCI"
   #type: "python_local"
   num_node: 4
 


### PR DESCRIPTION
Correcting typos in below files.

* README.md
* README_JP.md
* docs/source/user_guide/basic_usage.md
* examples/sphere/config.yaml