### PR TITLE
Fix typo in the Nelder-Mead optimizer

### DIFF
--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -111,7 +111,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
 
         Note:
             --------------------------------------------------------------
-            - befor
+            - before
             {
                 'vertex_id': 'CMTrNe5P8a',
                 'parameters': [


### PR DESCRIPTION
Correcting a mere typo on a docstring in /aiaccel/optimizer/nelder_mead_optimizer.py