### PR TITLE
Feature/fix util.process.py

### DIFF
--- a/aiaccel/util/process.py
+++ b/aiaccel/util/process.py
@@ -88,7 +88,7 @@ def ps2joblist() -> List[dict]:
         d = {
             'job-ID': p_info.info['pid'], 'prior': None, 'user': p_info.info['username'],
             'state': p_info.info['status'], 'queue': None, 'jclass': None,
-            'slots': None, 'ja-task-ID': None, 'name': " ".join(p_info.info['cmdline']),
+            'slots': None, 'ja-task-ID': None, 'name': " ".join(p_info.info['cmdline'] or []),
             'submit/start at': datetime.datetime.fromtimestamp(
                 p_info.info['create_time']).strftime("%Y-%m-%d %H:%M:%S")
         }

--- a/docs/source/examples/local_grid.md
+++ b/docs/source/examples/local_grid.md
@@ -36,6 +36,10 @@ generic:
 - **job_command** - ユーザープログラムを実行するためのコマンドです．
 - **batch_job_timeout** - ジョブのタイムアウト時間を設定します．[単位: 秒]
 
+```{note}
+Windows では，仮想環境の python で実行するためには `job_command` の欄を `"optenv/Scripts/python.exe"` のように設定する必要があります．
+```
+
 #### resource
 ```yaml
 resource:

--- a/docs/source/examples/local_random.md
+++ b/docs/source/examples/local_random.md
@@ -36,6 +36,10 @@ generic:
 - **job_command** - ユーザープログラムを実行するためのコマンドです．
 - **batch_job_timeout** - ジョブのタイムアウト時間を設定します．[単位: 秒]
 
+```{note}
+Windows では，仮想環境の python で実行するためには `job_command` の欄を `"optenv/Scripts/python.exe"` のように設定する必要があります．
+```
+
 #### resource
 ```yaml
 resource:


### PR DESCRIPTION
Fixed ps2joblist() in aiaccel.util.process.py to avoid error on Windows.

This pull request removes the error but please be aware that "job_command" in config.yaml for windows must be different form from that for Linux.
For Linux;
```
job_command: "python user.py"
```
For Windows;
```
job_command: "optenv\Scripts\python.exe"
```
This is written in docs/source/examples/local_grid.md and local_random.md.