### PR TITLE
Feature/fix float inf nan

### DIFF
--- a/aiaccel/util/easy_visualizer.py
+++ b/aiaccel/util/easy_visualizer.py
@@ -137,11 +137,11 @@ class EasyVisualizer:
                 message = "WARNING: result data has 'nan'"
                 print(f"{yellow}{message}{reset}")
                 return
-            if np.float("inf") in data[i]:
+            if float("inf") in data[i]:
                 message = "WARNING: result data has 'inf'"
                 print(f"{yellow}{message}{reset}")
                 return
-            if np.float("-inf") in data[i]:
+            if float("-inf") in data[i]:
                 message = "WARNING: result data has '-inf'"
                 print(f"{yellow}{message}{reset}")
                 return

--- a/aiaccel/util/process.py
+++ b/aiaccel/util/process.py
@@ -88,7 +88,7 @@ def ps2joblist() -> List[dict]:
         d = {
             'job-ID': p_info.info['pid'], 'prior': None, 'user': p_info.info['username'],
             'state': p_info.info['status'], 'queue': None, 'jclass': None,
-            'slots': None, 'ja-task-ID': None, 'name': " ".join(p_info.info['cmdline']),
+            'slots': None, 'ja-task-ID': None, 'name': " ".join(p_info.info['cmdline'] or []),
             'submit/start at': datetime.datetime.fromtimestamp(
                 p_info.info['create_time']).strftime("%Y-%m-%d %H:%M:%S")
         }

--- a/docs/source/examples/local_grid.md
+++ b/docs/source/examples/local_grid.md
@@ -36,6 +36,10 @@ generic:
 - **job_command** - ユーザープログラムを実行するためのコマンドです．
 - **batch_job_timeout** - ジョブのタイムアウト時間を設定します．[単位: 秒]
 
+```{note}
+Windows では，仮想環境の python で実行するためには `job_command` の欄を `"optenv/Scripts/python.exe"` のように設定する必要があります．
+```
+
 #### resource
 ```yaml
 resource:

--- a/docs/source/examples/local_random.md
+++ b/docs/source/examples/local_random.md
@@ -36,6 +36,10 @@ generic:
 - **job_command** - ユーザープログラムを実行するためのコマンドです．
 - **batch_job_timeout** - ジョブのタイムアウト時間を設定します．[単位: 秒]
 
+```{note}
+Windows では，仮想環境の python で実行するためには `job_command` の欄を `"optenv/Scripts/python.exe"` のように設定する必要があります．
+```
+
 #### resource
 ```yaml
 resource:

--- a/tests/unit/util_test/test_easy_visualizer.py
+++ b/tests/unit/util_test/test_easy_visualizer.py
@@ -1,6 +1,5 @@
 import shutil
 
-import numpy as np
 import pytest
 from aiaccel.util.easy_visualizer import EasyVisualizer
 
@@ -51,7 +50,7 @@ def test_line_plot():
     none_data = [1, None, 2, 3, 4]
     assert cplot.line_plot([none_data]) is None
 
-    nan_data = [1, np.float('nan'), 2, 3, 4]
+    nan_data = [1, float('nan'), 2, 3, 4]
     assert cplot.line_plot([nan_data]) is None
 
     inf_data = [1, float('inf'), 2, 3, 4]
@@ -81,4 +80,3 @@ def test_sort():
 
     goal = "invalid"
     assert cplot.sort(data, goal) == []
-


### PR DESCRIPTION
Replaced `np.float()` by `float()`.

This will make aiaccel-plot available with numpy1.24.0.
I did not employ `np.inf` or `np.nan` following the trend in optuna and pytorch.