### PR TITLE
replaced np.float by float

### DIFF
--- a/aiaccel/util/easy_visualizer.py
+++ b/aiaccel/util/easy_visualizer.py
@@ -137,11 +137,11 @@ class EasyVisualizer:
                 message = "WARNING: result data has 'nan'"
                 print(f"{yellow}{message}{reset}")
                 return
-            if np.float("inf") in data[i]:
+            if float("inf") in data[i]:
                 message = "WARNING: result data has 'inf'"
                 print(f"{yellow}{message}{reset}")
                 return
-            if np.float("-inf") in data[i]:
+            if float("-inf") in data[i]:
                 message = "WARNING: result data has '-inf'"
                 print(f"{yellow}{message}{reset}")
                 return

--- a/tests/unit/util_test/test_easy_visualizer.py
+++ b/tests/unit/util_test/test_easy_visualizer.py
@@ -1,6 +1,5 @@
 import shutil
 
-import numpy as np
 import pytest
 from aiaccel.util.easy_visualizer import EasyVisualizer
 
@@ -51,7 +50,7 @@ def test_line_plot():
     none_data = [1, None, 2, 3, 4]
     assert cplot.line_plot([none_data]) is None
 
-    nan_data = [1, np.float('nan'), 2, 3, 4]
+    nan_data = [1, float('nan'), 2, 3, 4]
     assert cplot.line_plot([nan_data]) is None
 
     inf_data = [1, float('inf'), 2, 3, 4]
@@ -81,4 +80,3 @@ def test_sort():
 
     goal = "invalid"
     assert cplot.sort(data, goal) == []
-


### PR DESCRIPTION
Replaced `np.float()` by `float()` for issure https://github.com/aistairc/aiaccel/issues/169.

This will make `aiaccel-plot` available with numpy1.24.0.
I did not employ `np.inf` and `np.nan` following the trend in optuna and pytorch.