### PR TITLE
Fix Typo

### DIFF
--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -135,7 +135,7 @@ class HyperParameter(object):
             self.step = parameter['step']
 
         if 'base' in parameter:
-            self.step = parameter['base']
+            self.base = parameter['base']
 
     def sample(self, initial: bool = False, rng: np.random.RandomState = None) -> dict:
         """Sample a parameter.


### PR DESCRIPTION
Grid search用オプションの`base`が設定されていた場合に，`base`の値で`step`の値が置き換わる現象を修正しました．

Fixed the problem that the value of `step` is replaced by the value of `base` when the option `base` for grid search is set.

close #158 