### PR TITLE
Change  yaml.safe_load to yaml.unsafe_load

### DIFF
--- a/aiaccel/scheduler/abstract_scheduler.py
+++ b/aiaccel/scheduler/abstract_scheduler.py
@@ -296,13 +296,13 @@ class AbstractScheduler(AbstractModule):
         result = self.storage.result.get_any_trial_objective(trial_id=trial_id)
         error = self.storage.error.get_any_trial_error(trial_id=trial_id)
 
-        content['result'] = str(result)
+        content['result'] = result
 
         if error is not None:
             content['error'] = error
 
         for i in range(len(content['parameters'])):
-            content['parameters'][i]['value'] = str(content['parameters'][i]['value'])
+            content['parameters'][i]['value'] = content['parameters'][i]['value']
 
         result_file_path = self.ws / dict_result / file_name
         create_yaml(result_file_path, content)

--- a/aiaccel/scheduler/job/model/abstract_model.py
+++ b/aiaccel/scheduler/job/model/abstract_model.py
@@ -277,7 +277,7 @@ class AbstractModel(object):
         result = obj.storage.result.get_any_trial_objective(trial_id=obj.trial_id)
         error = obj.storage.error.get_any_trial_error(trial_id=obj.trial_id)
         content = obj.storage.get_hp_dict(trial_id=obj.trial_id)
-        content['result'] = result
+        content['result'] = str(result)
 
         if error is not None:
             content['error'] = error

--- a/aiaccel/scheduler/job/model/abstract_model.py
+++ b/aiaccel/scheduler/job/model/abstract_model.py
@@ -277,7 +277,7 @@ class AbstractModel(object):
         result = obj.storage.result.get_any_trial_objective(trial_id=obj.trial_id)
         error = obj.storage.error.get_any_trial_error(trial_id=obj.trial_id)
         content = obj.storage.get_hp_dict(trial_id=obj.trial_id)
-        content['result'] = str(result)
+        content['result'] = result
 
         if error is not None:
             content['error'] = error

--- a/aiaccel/util/filesystem.py
+++ b/aiaccel/util/filesystem.py
@@ -181,11 +181,11 @@ def load_yaml(path: Path, dict_lock: Path = None) -> dict:
     """
     if dict_lock is None:
         with open(path, 'r') as f:
-            yml = yaml.load(f, Loader=yaml.SafeLoader)
+            yml = yaml.load(f, Loader=yaml.UnsafeLoader)
     else:
         with fasteners.InterProcessLock(interprocess_lock_file(path, dict_lock)):
             with open(path, 'r') as f:
-                yml = yaml.load(f, Loader=yaml.SafeLoader)
+                yml = yaml.load(f, Loader=yaml.UnsafeLoader)
     return yml
 
 

--- a/tests/unit/test_parameter.py
+++ b/tests/unit/test_parameter.py
@@ -30,7 +30,7 @@ class TestParameter(BaseTest):
             d = self.test_result_data[i]
             name = f"{d['trial_id']}.yml"
             path = work_dir / 'result' / name
-            d['result'] = str(results[i])
+            d['result'] = results[i]
             create_yaml(path, d)
 
         files = list(work_dir.joinpath(aiaccel.dict_result).glob('*.yml'))

--- a/tests/unit/test_parameter.py
+++ b/tests/unit/test_parameter.py
@@ -24,13 +24,13 @@ class TestParameter(BaseTest):
         assert best is None
         assert best_file is None
 
-        results = [120, 101., 140.]
+        results = [120, 101., np.float64(140.)]
 
         for i in range(len(self.test_result_data)):
             d = self.test_result_data[i]
             name = f"{d['trial_id']}.yml"
             path = work_dir / 'result' / name
-            d['result'] = results[i]
+            d['result'] = str(results[i])
             create_yaml(path, d)
 
         files = list(work_dir.joinpath(aiaccel.dict_result).glob('*.yml'))


### PR DESCRIPTION
aiaccel が numpy.float64 形式のデータをyaml保存したのち，同ファイルを aiaccel で load したとき，読み込みエラーが発生する問題を修正しました．

close #180 