### PR TITLE
Fix python3.9 error

### DIFF
--- a/aiaccel/util/aiaccel.py
+++ b/aiaccel/util/aiaccel.py
@@ -403,10 +403,8 @@ class Run:
 
         return xs, y, err
 
-    @ execute.register
-    def _(
-        self, command: str, trial_id: int, y_data_type: 'str | None'
-    ) -> 'tuple[dict[str, float | int | str] | None, float | int | str | None, str]':
+    @execute.register
+    def _(self, command: str, trial_id: int, y_data_type: str) -> tuple:
         """ Executes the user program.
 
         Args:
@@ -481,7 +479,7 @@ class Run:
         self.report(self.trial_id, xs, y, err, start_time, end_time)
 
     @execute_and_report.register
-    def _(self, command: str, y_data_type: 'str | None' = None) -> None:
+    def _(self, command: str, y_data_type: str = None) -> None:
         """Executes the user program.
 
         Args:


### PR DESCRIPTION
This PR fixes a python3.9 error related to type annotations.

The error arises from the fact that:
- python3.9 (or 3.8) cannot use the full functionality of type annotations.
- Type annotations also don't work well with @singledispatchmethod, especially for complex forms.

These have been improved since python3.10.

To resolve the error, some type annotations on methods registered with `Run.execute` and `Run.execute_and_report` are modified to simple form.

---

この PR では，型アノテーションに関連した python3.9 のエラーを修正します．

エラーは，次の原因から生じています;
- python3.9 (3.8) では型ヒントのすべての機能を使用できない．
- `@singledispatchmethod` は複雑な型ヒントと併用できない．

これらは，python3.10 で改善されているようです．

この PR では，エラーを回避するために `Run.execute` と `Run.execute_and_report` に登録される関数の型ヒントを簡略化します．

