### PR TITLE
fix IndexError in grid_optimizer

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -59,3 +59,4 @@ jobs:
           pytest -v tests/supplements/additional_resumption_test_benchmark/test_benchmark_tpe_resumption.py
           pytest -v tests/supplements/additional_resumption_test_benchmark/test_benchmark_nelder_mead_resumption.py
           pytest -v tests/supplements/random_generation_test_benchmark/test_benchmark_random_generation.py
+          pytest -v tests/supplements/additional_grid_test/test_benchmark_grid.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center"><img src="https://raw.githubusercontent.com/aistairc/aiaccel/master/docs/image/logo_aiaccel.png" width="400"/></div>
 
-# aiaccel: a HPO library for ABCI
+# aiaccel: an HPO library for ABCI
 [![GitHub license](https://img.shields.io/github/license/aistairc/aiaccel.svg)](https://github.com/aistairc/aiaccel)
 [![Supported Python version](https://img.shields.io/badge/Python-3.8-blue)](https://github.com/aistairc/aiaccel)
 [![Documentation Status](https://readthedocs.org/projects/aiaccel/badge/?version=latest)](https://aiaccel.readthedocs.io/en/latest/)

--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -164,7 +164,7 @@ class GridOptimizer(AbstractOptimizer):
         parameter_index = []
         div = [
             reduce(
-                lambda x, y: (x * y), parameter_lengths[i + 1:]
+                lambda x, y: x * y, parameter_lengths[i + 1:]
             ) for i in range(0, len(parameter_lengths) - 1)
         ]
 

--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -164,7 +164,7 @@ class GridOptimizer(AbstractOptimizer):
         parameter_index = []
         div = [
             reduce(
-                lambda x, y: x * y, parameter_lengths[0:-1 - i]
+                lambda x, y: (x * y), parameter_lengths[i + 1:]
             ) for i in range(0, len(parameter_lengths) - 1)
         ]
 
@@ -189,7 +189,8 @@ class GridOptimizer(AbstractOptimizer):
 
         if parameter_index is None:
             self.logger.info('Generated all of parameters.')
-            self.all_parameter_generated = True
+            if self.storage.get_num_finished() >= self.generate_index:
+                self.all_parameter_generated = True
             return new_params
 
         for i in range(0, len(self.ready_params)):

--- a/tests/supplements/additional_grid_test.py
+++ b/tests/supplements/additional_grid_test.py
@@ -1,0 +1,37 @@
+# Test grid search when given an irregular grid.
+
+import subprocess
+from pathlib import Path
+
+import aiaccel
+from aiaccel.config import Config
+from aiaccel.storage.storage import Storage
+
+from tests.base_test import BaseTest
+
+
+class AdditionalGridTest(BaseTest):
+    search_algorithm = None
+
+    def test_run(self, work_dir, create_tmp_config):
+        test_data_dir = Path(__file__).resolve().parent.joinpath('additional_grid_test', 'test_data')
+        config_file = test_data_dir.joinpath('config_{}.yaml'.format(self.search_algorithm))
+        config_file = create_tmp_config(config_file)
+        self.config = Config(config_file)
+        python_file = test_data_dir.joinpath('user.py')
+
+        with self.create_main(python_file):
+            storage = Storage(ws=Path(self.config.workspace.get()))
+            subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']
+                             ).wait(timeout=self.config.batch_job_timeout.get())
+        self.evaluate(work_dir, storage)
+
+    def evaluate(self, work_dir, storage):
+        running = storage.get_num_running()
+        ready = storage.get_num_ready()
+        finished = storage.get_num_finished()
+        assert finished == self.config.trial_number.get()
+        assert ready == 0
+        assert running == 0
+        final_result = work_dir.joinpath(aiaccel.dict_result, aiaccel.file_final_result)
+        assert final_result.exists()

--- a/tests/supplements/additional_grid_test/test_benchmark_grid.py
+++ b/tests/supplements/additional_grid_test/test_benchmark_grid.py
@@ -1,0 +1,9 @@
+
+from tests.supplements.additional_grid_test import AdditionalGridTest
+
+
+class TestBenchmarkGrid(AdditionalGridTest):
+
+    @classmethod
+    def setup_class(cls):
+        cls.search_algorithm = "grid"

--- a/tests/supplements/additional_grid_test/test_data/config_grid.yaml
+++ b/tests/supplements/additional_grid_test/test_data/config_grid.yaml
@@ -1,0 +1,84 @@
+generic:
+  workspace: "/tmp/work"
+  job_command: "python original_main.py"
+  batch_job_timeout: 600
+  sleep_time: 0
+
+resource:
+  type: "local"
+  num_node: 30
+
+ABCI:
+  group: "[group]"
+  job_script_preamble: "./job_script_preamble.sh"
+  job_execution_options: ""
+
+optimize:
+  search_algorithm: "aiaccel.optimizer.GridOptimizer"
+  goal: "minimize"
+  trial_number: 30
+  rand_seed: 42
+  parameters:
+    -
+      name: "x1"
+      type: "uniform_float"
+      lower: 2.0
+      upper: 6.0
+      step: 1
+      log: true
+      base: 2
+    -
+      name: "x2"
+      type: "uniform_int"
+      lower: 1
+      upper: 3
+      step: 1
+      log: false
+      base: 10
+    -
+      name: "x3"
+      type: "categorical"
+      choices: [1, 5]
+  
+job_setting:
+  cancel_retry: 3
+  cancel_timeout: 60
+  expire_retry: 3
+  expire_timeout: 60
+  finished_retry: 3
+  finished_timeout: 60
+  job_loop_duration: 0.5
+  job_retry: 2
+  job_timeout: 60
+  kill_retry: 3
+  kill_timeout: 60
+  result_retry: 1
+  runner_retry: 3
+  runner_timeout: 60
+  running_retry: 3
+  running_timeout: 60
+  init_fail_count: 100
+  name_length: 6
+
+# sleep_time: 0
+  # master: 1
+  # scheduler: 1
+  # optimizer: 1
+
+logger:
+  file:
+    master: "master.log"
+    optimizer: "optimizer.log"
+    scheduler: "scheduler.log"
+  log_level:
+    master: "DEBUG"
+    optimizer: "DEBUG"
+    scheduler: "DEBUG"
+  stream_level:
+    master: "DEBUG"
+    optimizer: "CRITICAL"
+    scheduler: "CRITICAL"
+
+verification:
+  is_verified: false
+  condition: []

--- a/tests/supplements/additional_grid_test/test_data/user.py
+++ b/tests/supplements/additional_grid_test/test_data/user.py
@@ -1,0 +1,14 @@
+from aiaccel.util import aiaccel
+import numpy as np
+
+
+def main(p):
+    x = np.array([p["x1"], p["x2"], p["x3"]])
+    y = np.sum(x ** 2)
+    return y
+
+
+if __name__ == "__main__":
+
+    run = aiaccel.Run()
+    run.execute_and_report(main)


### PR DESCRIPTION
グリッドサーチで IndexError が発生する現象を修正しました。

- div の生成方法が間違っていたので、修正しました。
  - div は、生成パラメータ数からグリッドの点を生成する際に用いるリストです。
  - 例えば、comfigのパラメータが下記のような場合、div の値は [6, 2] になるはずが、[9,3] になっていました。
    - int(生成パラメータ数 / div[0]) をx1のグリッドの値にして、(生成パラメータ数 / div[0]の余りを用いて、int(余り / div[1]) をx2 のグリッドの値にして・・・というのを繰り返し、最後の余りをx3のグリッドの値にする。という風にグリッドの値を生成しています。
  ```
      parameters:
      -
        name: "x1"
        type: "categorical"
        choices: [1, 2, 3]
      -
        name: "x2"
        type: "categorical"
        choices: [1, 2, 3]
      -
        name: "x3"
        type: "categorical"
        choices: [1, 2]
  ```
  - これにより特定条件下(例えば、3x3x2のような各グリッドの点が数が揃っていない、特に最後のパラメータの点の数が異なる時)においてリスト外の参照が発生(IndexError)していたので、正しいdiv が計算されるように修正しました。
  - この部分の実装は、numpy.meshgrid を使ったほうが良いかもしれません。 https://numpy.org/doc/stable/reference/generated/numpy.meshgrid.html
- また、パラメータ生成完了直後に`self.all_parameter_generated = True`を実行すると、計算ジョブが投げられる前にoptimizerが落ちて、aiaccelが終了してしまうことがあったので、`self.all_parameter_generated = True`を全パラメータ計算完了後に実行するように変更しました。

close #232 