### PR TITLE
Limit sqlalchemy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML>=5.4
-SQLAlchemy
+SQLAlchemy==1.4.27
 asciichartpy
 confile
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML>=5.4
-SQLAlchemy==1.4.27
+SQLAlchemy==1.4.46
 asciichartpy
 confile
 coverage


### PR DESCRIPTION
sqlalchemy のバージョン指定を復活させました．
`declarative_base` のインポート方法は変更していません．

close #235 