### PR TITLE
Mypy error elimination by `typing.Any`

### DIFF
--- a/aiaccel/abci/batch.py
+++ b/aiaccel/abci/batch.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Any
 
 from aiaccel.util.filesystem import file_create
 
@@ -6,7 +9,7 @@ from aiaccel.util.filesystem import file_create
 def create_abci_batch_file(
     batch_file: Path,
     wrapper_file: str,
-    commands: list,
+    commands: list[Any],
     dict_lock: Path
 ) -> None:
     """Create a ABCI batch file.

--- a/aiaccel/abci/qstat.py
+++ b/aiaccel/abci/qstat.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+from typing import Any
+
 import xml.etree.ElementTree as ElementTree
 from xml.etree.ElementTree import Element
 
@@ -20,7 +23,7 @@ stat = {
 '''
 
 
-def parse_qstat(config: Config, qstat: str) -> list[dict]:
+def parse_qstat(config: Config, qstat: str) -> list[dict[str, Any]]:
     """Parse ABCI 'qstat' command result.
 
     Args:
@@ -42,7 +45,7 @@ def parse_qstat(config: Config, qstat: str) -> list[dict]:
     return stat_list
 
 
-def parse_job_list(config: Config, job_list: Element) -> list[dict]:
+def parse_job_list(config: Config, job_list: Element) -> list[dict[str, Any]]:
     """Parse from XML element of 'qstat' to a job list.
 
     Args:

--- a/aiaccel/cli/view.py
+++ b/aiaccel/cli/view.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from argparse import ArgumentParser
 from pathlib import Path
+from typing import Any
 
 from numpy import maximum
 
@@ -64,7 +67,7 @@ class Viewer:
                 }
             )
 
-        max_column_width = []
+        max_column_width: list[Any] = []
         for info in infos:
             width = [len(info[key]) + len_margin for key in list(info.keys())]
             header_width = [len(key) + len_margin for key in list(info.keys())]

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -25,11 +25,11 @@ class BaseConfig(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def get_property(self, key, *keys):
+    def get_property(self, key: Any, *keys: Any) -> Any:
         pass
 
     @abstractmethod
-    def to_dict(self):
+    def to_dict(self) -> Any:
         pass
 
 
@@ -43,13 +43,13 @@ class JsonOrYamlObjectConfig(BaseConfig):
         file_type (str): 'json_object' or 'yaml_object'.
     """
 
-    def __init__(self, config: dict, file_type: str) -> None:
+    def __init__(self, config: dict[str, Any], file_type: str) -> None:
         if file_type in ['json_object', 'yaml_object']:
             self._config_dict = config
         else:
             raise TypeError(f'Unknown file type {file_type}')
 
-    def get_property(self, key: str, *keys: str) -> str | list | dict | None:
+    def get_property(self, key: str, *keys: str) -> str | list[Any] | dict[str, Any] | None:
         """Get a property for specified keys.
 
         Args:
@@ -75,7 +75,7 @@ class JsonOrYamlObjectConfig(BaseConfig):
         else:
             return sub_config_dict
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert the configuration to a dictionary object.
 
@@ -113,7 +113,7 @@ class ConfileWrapper(object):
         elif config_type in ['json_object', 'yaml_object']:
             self.config = JsonOrYamlObjectConfig(config, config_type)
 
-    def get(self, key: str, *keys: str) -> str | list | dict | None:
+    def get(self, key: str, *keys: str) -> str | list[Any] | dict[str, Any] | None:
         """Get a property with specified keys.
 
         Args:
@@ -182,11 +182,11 @@ class ConfigEntry:
     def __init__(
         self,
         config: ConfileWrapper,
-        type: list,
+        type: list[Any],
         default: Any,
         warning: bool,
         group: str,
-        keys: list | tuple | str
+        keys: Any
     ) -> None:
         self.config = config
         self.group = group
@@ -208,7 +208,7 @@ class ConfigEntry:
         """
         return copy.deepcopy(self._value)
 
-    def set(self, value) -> None:
+    def set(self, value: Any) -> None:
         """
         Args
             value (any)
@@ -238,7 +238,7 @@ class ConfigEntry:
                 f"the default value will be applied.(default: {self.default})"
             )
 
-    def empty_if_error(self):
+    def empty_if_error(self) -> None:
         """ If the value is not set, it will force an error to occur.
         """
         if (
@@ -250,13 +250,10 @@ class ConfigEntry:
             logger.error(f"Configuration error. '{self.keys}' is not found.")
             sys.exit()
 
-    def load_config_values(self):
+    def load_config_values(self) -> None:
         """ Reads values from the configuration file.
         """
-        if (
-            type(self.keys) is list or
-            type(self.keys) is tuple
-        ):
+        if isinstance(self.keys, (list, tuple)):
             value = self.config.get(self.group, *self.keys)
         else:
             value = self.config.get(self.group, self.keys)
@@ -270,7 +267,7 @@ class ConfigEntry:
             self.read_values_from_config_file = True
 
     @ property
-    def Value(self):
+    def Value(self) -> Any | None:
         return self._value
 
 
@@ -316,9 +313,9 @@ _DEFAULT_ABCI_GROUP = ""
 _DEFAULT_JOB_EXECUTION_OPTIONS = ""
 _DEFAULT_GOAL = "minimize"
 _DEFAULT_MAX_TRIAL_NUMBER = 0
-_DEFAULT_HYPERPARAMETERS: list = []
+_DEFAULT_HYPERPARAMETERS: list[Any] = []
 _DEFAULT_IS_VERIFIED = False
-_DEFAULT_VERIFI_CONDITION: list = []
+_DEFAULT_VERIFI_CONDITION: list[Any] = []
 _DEFAULT_RANDOM_SCHESULING = True
 _DEFAULT_SOBOL_SCRAMBLE = True
 _DEFAULT_PYTHON_FILE = ""

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -351,7 +351,7 @@ class Config:
         if not self.config_path.exists():
             logger.error(f"config file: {config_path} doesn't exist.")
 
-        self.config = load_config(config_path)
+        self.config = load_config(str(config_path))
         self.define_items(self.config, warn)
         if format_check:
             self.workspace.empty_if_error()

--- a/aiaccel/master/abci_master.py
+++ b/aiaccel/master/abci_master.py
@@ -49,12 +49,12 @@ class AbciMaster(AbstractMaster):
         p = subprocess.Popen(commands, stdout=subprocess.PIPE, shell=True)
 
         try:
-            stats, errs = p.communicate(timeout=1)
+            stdout_data, _ = p.communicate(timeout=1)
         except subprocess.TimeoutExpired:
             p.kill()
-            stats, errs = p.communicate()
+            stdout_data, _ = p.communicate()
 
-        stats = stats.decode('utf-8')
+        stats = stdout_data.decode('utf-8')
 
         # Write qstat result
         lines = ''

--- a/aiaccel/master/abstract_master.py
+++ b/aiaccel/master/abstract_master.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
 
 import aiaccel
 from aiaccel.master.evaluator.maximize_evaluator import MaximizeEvaluator
@@ -37,7 +40,7 @@ class AbstractMaster(AbstractModule):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         self.start_time = get_time_now_object()
-        self.loop_start_time = None
+        self.loop_start_time: datetime | None = None
         self.options = options
         self.options['process_name'] = 'master'
 
@@ -57,8 +60,8 @@ class AbstractMaster(AbstractModule):
         self.goal = self.config.goal.get()
         self.trial_number = self.config.trial_number.get()
 
-        self.runner_files = []
-        self.stats = []
+        self.runner_files: list[Path] | None = []
+        self.stats: list[Any] = []
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.
@@ -86,6 +89,7 @@ class AbstractMaster(AbstractModule):
         if not self.check_finished():
             return
 
+        evaluator: MaximizeEvaluator | MinimizeEvaluator
         if self.goal.lower() == aiaccel.goal_maximize:
             evaluator = MaximizeEvaluator(self.options)
         elif self.goal.lower() == aiaccel.goal_minimize:

--- a/aiaccel/master/abstract_master.py
+++ b/aiaccel/master/abstract_master.py
@@ -162,7 +162,7 @@ class AbstractMaster(AbstractModule):
         """
         return None
 
-    def check_error(self):
+    def check_error(self) -> bool:
         """ Check to confirm if an error has occurred.
 
         Args:

--- a/aiaccel/master/create.py
+++ b/aiaccel/master/create.py
@@ -6,16 +6,16 @@ from aiaccel.master.local_master import LocalMaster
 from aiaccel.master.pylocal_master import PylocalMaster
 
 
-def create_master(config_path: str) -> type | None:
+def create_master(config_path: str) -> type:
     """Returns master type.
 
     Args:
         config_path (str): Path to configuration file.
 
     Returns:
-        type | None: `LocalMaster`, `PylocalMaster`, or `AbciMaster`
+        type: `LocalMaster`, `PylocalMaster`, or `AbciMaster`
             if resource type is 'local', 'python_local', or 'abci',
-            respectively. Other cases, None.
+            respectively.
     """
     config = Config(config_path)
     resource = config.resource_type.get()
@@ -30,4 +30,4 @@ def create_master(config_path: str) -> type | None:
         return AbciMaster
 
     else:
-        return None
+        raise ValueError("Resource type is 'local', 'python_local', or 'abci'")

--- a/aiaccel/master/create.py
+++ b/aiaccel/master/create.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
+from typing import Any
+
 from aiaccel.config import Config
 from aiaccel.master.abci_master import AbciMaster
 from aiaccel.master.local_master import LocalMaster
 from aiaccel.master.pylocal_master import PylocalMaster
 
 
-def create_master(config_path: str) -> type:
+def create_master(config_path: str) -> Any:
     """Returns master type.
 
     Args:
         config_path (str): Path to configuration file.
 
     Returns:
-        type: `LocalMaster`, `PylocalMaster`, or `AbciMaster`
+        type | None: `LocalMaster`, `PylocalMaster`, or `AbciMaster`
             if resource type is 'local', 'python_local', or 'abci',
-            respectively.
+            respectively. Other cases, None.
     """
     config = Config(config_path)
     resource = config.resource_type.get()
@@ -30,4 +32,4 @@ def create_master(config_path: str) -> type:
         return AbciMaster
 
     else:
-        raise ValueError("Resource type is 'local', 'python_local', or 'abci'")
+        return None

--- a/aiaccel/master/evaluator/abstract_evaluator.py
+++ b/aiaccel/master/evaluator/abstract_evaluator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import aiaccel
 from aiaccel.config import Config
@@ -31,13 +32,13 @@ class AbstractEvaluator(object):
 
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: dict[str, Any]) -> None:
         self.options = options
         self.config_path = Path(self.options['config']).resolve()
         self.config = Config(str(self.config_path))
         self.ws = Path(self.config.workspace.get()).resolve()
         self.dict_lock = self.ws / aiaccel.dict_lock
-        self.hp_result = None
+        self.hp_result: dict | None = None
         self.storage = Storage(self.ws)
         self.goal = self.config.goal.get()
         self.trial_id = TrialId(str(self.config_path))

--- a/aiaccel/master/evaluator/abstract_evaluator.py
+++ b/aiaccel/master/evaluator/abstract_evaluator.py
@@ -38,7 +38,7 @@ class AbstractEvaluator(object):
         self.config = Config(str(self.config_path))
         self.ws = Path(self.config.workspace.get()).resolve()
         self.dict_lock = self.ws / aiaccel.dict_lock
-        self.hp_result: dict | None = None
+        self.hp_result: dict[str, Any] | None = None
         self.storage = Storage(self.ws)
         self.goal = self.config.goal.get()
         self.trial_id = TrialId(str(self.config_path))

--- a/aiaccel/master/verification/abstract_verification.py
+++ b/aiaccel/master/verification/abstract_verification.py
@@ -44,8 +44,8 @@ class AbstractVerification(object):
         self.dict_lock = self.ws / aiaccel.dict_lock
         self.is_verified: bool = False
         self.finished_loop = None
-        self.condition: list[dict[str, Any]]
-        self.verification_result: list[dict[str, Any]]
+        self.condition: Any = None
+        self.verification_result: Any = None
         self.load_verification_config()
         self.storage = Storage(self.ws)
 

--- a/aiaccel/master/verification/abstract_verification.py
+++ b/aiaccel/master/verification/abstract_verification.py
@@ -140,7 +140,7 @@ class AbstractVerification(object):
         logger.info('Current verification is followings:')
         logger.info(f'{self.verification_result}')
 
-    def save(self, name: int) -> None:
+    def save(self, name: str | int) -> None:
         """Save current verifications result to a file.
 
         Args:

--- a/aiaccel/master/verification/abstract_verification.py
+++ b/aiaccel/master/verification/abstract_verification.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 from pathlib import Path
+from typing import Any
 
 import aiaccel
 from aiaccel.config import Config
@@ -35,16 +36,16 @@ class AbstractVerification(object):
         storage (Storage): Storage object.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: dict[str, Any]) -> None:
         # === Load config file===
         self.options = options
         self.config = Config(self.options['config'])
         self.ws = Path(self.config.workspace.get()).resolve()
         self.dict_lock = self.ws / aiaccel.dict_lock
-        self.is_verified: bool = None
+        self.is_verified: bool = False
         self.finished_loop = None
-        self.condition = None
-        self.verification_result = None
+        self.condition: list[dict[str, Any]]
+        self.verification_result: list[dict[str, Any]]
         self.load_verification_config()
         self.storage = Storage(self.ws)
 

--- a/aiaccel/module.py
+++ b/aiaccel/module.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -49,7 +50,7 @@ class AbstractModule(object):
         loop_count (int): A loop count that is incremented in loop method.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: dict[str, Any]) -> None:
         # === Load config file===
         self.options = options
         self.config_path = Path(self.options['config']).resolve()
@@ -75,7 +76,7 @@ class AbstractModule(object):
         self.alive_optimizer = self.dict_alive / aiaccel.alive_optimizer
         self.alive_scheduler = self.dict_alive / aiaccel.alive_scheduler
 
-        self.logger = None
+        self.logger: logging.Logger
         self.fh = None
         self.ch = None
         self.ch_formatter = None
@@ -87,7 +88,7 @@ class AbstractModule(object):
         self.storage = Storage(self.ws)
         self.trial_id = TrialId(self.options['config'])
         # TODO: Separate the generator if don't want to affect randomness each other.
-        self._rng: np.random.RandomState | None = None
+        self._rng: np.random.RandomState
 
         self.storage.variable.register(
             process_name=self.options['process_name'],
@@ -170,17 +171,17 @@ class AbstractModule(object):
         self.logger = logging.getLogger(logger_name)
         self.logger.setLevel(logging.DEBUG)
         fh = logging.FileHandler(logfile, mode='w')
-        fh_formatter = (
+        fh_formatter = logging.Formatter(
             '%(asctime)s %(levelname)-8s %(filename)-12s line '
             '%(lineno)-4s %(message)s'
         )
-        fh_formatter = logging.Formatter(fh_formatter)
         fh.setFormatter(fh_formatter)
         fh.setLevel(file_level)
 
         ch = logging.StreamHandler()
-        ch_formatter = (f'{module_type} %(levelname)-8s %(message)s')
-        ch_formatter = logging.Formatter(ch_formatter)
+        ch_formatter = logging.Formatter(
+            f'{module_type} %(levelname)-8s %(message)s'
+        )
         ch.setFormatter(ch_formatter)
         ch.setLevel(stream_level)
 
@@ -267,7 +268,7 @@ class AbstractModule(object):
         self.logger.debug(f'create numpy random generator by seed: {self.seed}')
         self._rng = np.random.RandomState(self.seed)
 
-    def get_numpy_random_state(self) -> tuple:
+    def get_numpy_random_state(self) -> Any:
         """ get random state.
 
         Args:
@@ -278,7 +279,7 @@ class AbstractModule(object):
         """
         return self._rng.get_state()
 
-    def set_numpy_random_state(self, state: tuple) -> None:
+    def set_numpy_random_state(self, state: Any) -> None:
         """ get random state.
 
         Args:

--- a/aiaccel/module.py
+++ b/aiaccel/module.py
@@ -88,7 +88,7 @@ class AbstractModule(object):
         self.storage = Storage(self.ws)
         self.trial_id = TrialId(self.options['config'])
         # TODO: Separate the generator if don't want to affect randomness each other.
-        self._rng: np.random.RandomState
+        self._rng: Any = None
 
         self.storage.variable.register(
             process_name=self.options['process_name'],

--- a/aiaccel/module.py
+++ b/aiaccel/module.py
@@ -76,10 +76,10 @@ class AbstractModule(object):
         self.alive_optimizer = self.dict_alive / aiaccel.alive_optimizer
         self.alive_scheduler = self.dict_alive / aiaccel.alive_scheduler
 
-        self.logger: logging.Logger
-        self.fh = None
-        self.ch = None
-        self.ch_formatter = None
+        self.logger: Any = None
+        self.fh: Any = None
+        self.ch: Any = None
+        self.ch_formatter: Any = None
         self.loop_count = 0
         self.hp_ready = 0
         self.hp_running = 0

--- a/aiaccel/module.py
+++ b/aiaccel/module.py
@@ -317,7 +317,7 @@ class AbstractModule(object):
         ):
             self._deserialize(self.options['resume'])
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         obj = self.__dict__.copy()
         del obj['storage']
         del obj['config']

--- a/aiaccel/optimizer/_nelder_mead.py
+++ b/aiaccel/optimizer/_nelder_mead.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 import logging
+from typing import Any
 
 import numpy as np
 
@@ -74,10 +76,10 @@ class NelderMead(object):
     def __init__(
         self,
         params: list[HyperParameter],
-        iteration: float | None = float('inf'),
+        iteration: float = float('inf'),
         coef: dict | None = None,
         maximize: bool | None = False,
-        initial_parameters: list[dict[str, str | float | list[float]]] | None = None,
+        initial_parameters: list[dict[str, Any]] | None = None,
         rng: np.random.RandomState | None = None
     ) -> None:
         if coef is None:
@@ -92,14 +94,14 @@ class NelderMead(object):
 
         self.y = self._create_initial_values(initial_parameters)
 
-        self.f = []
+        self.f: Any = []  # np.ndarray is assigned in self._wait_initialize().
         self.yc = None
         self._storage = {
             "r": None, "ic": None, "oc": None, "e": None, "s": None}
         self._max_itr = iteration
         self._total_itr = 0         # included out of boundary
         self._evaluated_itr = 0     # not included out of boundary
-        self._history = {
+        self._history: dict[str, list[Any]] = {
             'total_y': [],              # y each loop
             'evaluated_y': [],          # y each loop not included out of boundary
             'op': [],                   # operations such as 'reflect' and so on.
@@ -108,23 +110,22 @@ class NelderMead(object):
             'fyr_order': []             # order of f(yr) in self.f
         }
         self._executing_index = 0
-        self._executing = []
-        self._fr = None
-        self._fe = None
-        self._fic = None
-        self._foc = None
+        self._executing: list[Any] = []
+        self._fr: Any  # treated as "float" until self._finalize() where "None" is assigned.
+        self._fe: Any
+        self._fic: Any
+        self._foc: Any
         self._maximize = maximize
         self._num_shrink = 0
         self._state = 'WaitInitialize'
         self._out_of_boundary = False
-        self._result = []
+        self._result: list[Any] = []
         for y in self.y:
             self._add_executing(y)
 
     def _create_initial_values(
         self,
-        initial_parameters: list[dict[str, int | np.integer | float |
-                                      np.floating | list[int | np.integer | float | np.floating | str]]]
+        initial_parameters: list[dict[str, Any]]
     ) -> np.ndarray:
         initial_values = [
             [self._create_initial_value(initial_parameters, dim, num_of_initials) for dim in range(len(self.params))]
@@ -135,8 +136,7 @@ class NelderMead(object):
 
     def _create_initial_value(
         self,
-        initial_parameters: list[
-            dict[str, int | np.integer | float | np.floating | list[int | np.integer | float | np.floating | str]]],
+        initial_parameters: Any,
         dim: int,
         num_of_initials: int
     ) -> int | np.integer | float | np.floating | list[int | np.integer | float | np.floating | str]:

--- a/aiaccel/optimizer/_nelder_mead.py
+++ b/aiaccel/optimizer/_nelder_mead.py
@@ -111,10 +111,10 @@ class NelderMead(object):
         }
         self._executing_index = 0
         self._executing: list[Any] = []
-        self._fr: Any  # treated as "float" until self._finalize() where "None" is assigned.
-        self._fe: Any
-        self._fic: Any
-        self._foc: Any
+        self._fr: Any = None  # treated as "float" until self._finalize() where "None" is assigned.
+        self._fe: Any = None
+        self._fic: Any = None
+        self._foc: Any = None
         self._maximize = maximize
         self._num_shrink = 0
         self._state = 'WaitInitialize'

--- a/aiaccel/optimizer/_nelder_mead.py
+++ b/aiaccel/optimizer/_nelder_mead.py
@@ -77,7 +77,7 @@ class NelderMead(object):
         self,
         params: list[HyperParameter],
         iteration: float = float('inf'),
-        coef: dict | None = None,
+        coef: dict[str, Any] | None = None,
         maximize: bool | None = False,
         initial_parameters: Any = None,
         rng: np.random.RandomState | None = None
@@ -126,7 +126,7 @@ class NelderMead(object):
     def _create_initial_values(
         self,
         initial_parameters: list[dict[str, Any]]
-    ) -> np.ndarray:
+    ) -> np.ndarray[Any, Any]:
         initial_values = [
             [self._create_initial_value(initial_parameters, dim, num_of_initials) for dim in range(len(self.params))]
             for num_of_initials in range(self.n_dim + 1)
@@ -139,7 +139,7 @@ class NelderMead(object):
         initial_parameters: Any,
         dim: int,
         num_of_initials: int
-    ) -> int | np.integer | float | np.floating | list[int | np.integer | float | np.floating | str]:
+    ) -> int | np.integer[Any] | float | np.floating[Any] | list[int | np.integer[Any] | float | np.floating[Any] | str]:
         if initial_parameters is not None:
             if isinstance(initial_parameters[dim]['value'], (int, float, np.integer, np.floating)):
                 initial_parameters[dim]['value'] = [initial_parameters[dim]['value']]
@@ -164,7 +164,7 @@ class NelderMead(object):
             return val
 
     def _add_executing(
-        self, y: np.ndarray,
+        self, y: np.ndarray[Any, Any],
         index: int | None = None
     ) -> None:
         """Add a parameter set to an execution candidate.
@@ -228,7 +228,7 @@ class NelderMead(object):
             self._history['evaluated_y'].append(self.y)
         self._history['total_y'].append(self.y)
 
-    def _pop_result(self) -> dict | None:
+    def _pop_result(self) -> dict[str, Any] | None:
         """Pop a result.
 
         Returns:
@@ -284,7 +284,7 @@ class NelderMead(object):
 
         self._state = state
 
-    def _wait_initialize(self, results: list[dict]) -> None:
+    def _wait_initialize(self, results: list[dict[str, Any]]) -> None:
         """Wait first parameter results are finished.
 
         Args:
@@ -310,7 +310,7 @@ class NelderMead(object):
         self._centroid()
         self._reflect()
 
-    def _wait_reflect(self, results: list[dict]) -> None:
+    def _wait_reflect(self, results: list[dict[str, Any]]) -> None:
         """Wait Reflect calculations are finished.
 
         Args:
@@ -343,7 +343,7 @@ class NelderMead(object):
         else:  # pragma: no cover
             pass  # not reached
 
-    def _wait_expand(self, results: list[dict]) -> None:
+    def _wait_expand(self, results: list[dict[str, Any]]) -> None:
         """Wait 'Expand' executions finished.
 
         Args:
@@ -371,7 +371,7 @@ class NelderMead(object):
             self.f[-1] = self._fr
         self._finalize()
 
-    def _wait_outside_contract(self, results: list[dict]) -> None:
+    def _wait_outside_contract(self, results: list[dict[str, Any]]) -> None:
         """Wait the 'OutsideContract' execution finished.
 
         Args:
@@ -398,7 +398,7 @@ class NelderMead(object):
         else:
             self._shrink()
 
-    def _wait_inside_contract(self, results: list[dict]) -> None:
+    def _wait_inside_contract(self, results: list[dict[str, Any]]) -> None:
         """Wait the 'InsideContract' execution finished.
 
         Args:
@@ -426,7 +426,7 @@ class NelderMead(object):
         else:
             self._shrink()
 
-    def _wait_shrink(self, results: list[dict]) -> None:
+    def _wait_shrink(self, results: list[dict[str, Any]]) -> None:
         """Wait the 'Shrink' execution finished.
 
         Args:
@@ -564,7 +564,7 @@ class NelderMead(object):
 
         self._history['op'].append('s')
 
-    def _is_out_of_boundary(self, y: np.ndarray) -> bool:
+    def _is_out_of_boundary(self, y: np.ndarray[Any, Any]) -> bool:
         """Is points out of boundary or not.
 
         Args:
@@ -579,7 +579,7 @@ class NelderMead(object):
 
         return False
 
-    def add_result_parameters(self, result: dict) -> None:
+    def add_result_parameters(self, result: dict[str, Any]) -> None:
         """Add a new result.
 
         Args:
@@ -590,7 +590,7 @@ class NelderMead(object):
         """
         self._result.append(result)
 
-    def search(self) -> list[dict] | None:
+    def search(self) -> list[dict[str, Any]] | None:
         """Proceed a search step. One search method does not increment the
             iteration. It increments when finalize method is called.
 

--- a/aiaccel/optimizer/_nelder_mead.py
+++ b/aiaccel/optimizer/_nelder_mead.py
@@ -79,7 +79,7 @@ class NelderMead(object):
         iteration: float = float('inf'),
         coef: dict | None = None,
         maximize: bool | None = False,
-        initial_parameters: list[dict[str, Any]] | None = None,
+        initial_parameters: Any = None,
         rng: np.random.RandomState | None = None
     ) -> None:
         if coef is None:

--- a/aiaccel/optimizer/_nelder_mead.py
+++ b/aiaccel/optimizer/_nelder_mead.py
@@ -139,7 +139,7 @@ class NelderMead(object):
         initial_parameters: Any,
         dim: int,
         num_of_initials: int
-    ) -> int | np.integer[Any] | float | np.floating[Any] | list[int | np.integer[Any] | float | np.floating[Any] | str]:
+    ) -> Any:
         if initial_parameters is not None:
             if isinstance(initial_parameters[dim]['value'], (int, float, np.integer, np.floating)):
                 initial_parameters[dim]['value'] = [initial_parameters[dim]['value']]

--- a/aiaccel/optimizer/abstract_optimizer.py
+++ b/aiaccel/optimizer/abstract_optimizer.py
@@ -235,7 +235,7 @@ class AbstractOptimizer(AbstractModule):
             self.trial_id.initial(num=self.options['resume'])
             self._deserialize(self.options['resume'])
 
-    def cast(self, params: list[dict[str, Any]]) -> list | None:
+    def cast(self, params: list[dict[str, Any]]) -> list[Any] | None:
         """Casts types of parameter values to appropriate tepes.
 
         Args:

--- a/aiaccel/optimizer/abstract_optimizer.py
+++ b/aiaccel/optimizer/abstract_optimizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import copy
+from typing import Any
 
 from aiaccel.module import AbstractModule
 from aiaccel.parameter import load_parameter
@@ -89,7 +90,7 @@ class AbstractOptimizer(AbstractModule):
 
     def generate_initial_parameter(
         self
-    ) -> list[dict[str, float | int | str]]:
+    ) -> list[dict[str, Any]] | None:
         """Generate a list of initial parameters.
 
         Returns:
@@ -234,7 +235,7 @@ class AbstractOptimizer(AbstractModule):
             self.trial_id.initial(num=self.options['resume'])
             self._deserialize(self.options['resume'])
 
-    def cast(self, params: list[dict[str, str | float | int]]) -> list | None:
+    def cast(self, params: list[dict[str, Any]]) -> list | None:
         """Casts types of parameter values to appropriate tepes.
 
         Args:

--- a/aiaccel/optimizer/abstract_optimizer.py
+++ b/aiaccel/optimizer/abstract_optimizer.py
@@ -90,7 +90,7 @@ class AbstractOptimizer(AbstractModule):
 
     def generate_initial_parameter(
         self
-    ) -> list[dict[str, Any]] | None:
+    ) -> Any:
         """Generate a list of initial parameters.
 
         Returns:
@@ -110,7 +110,7 @@ class AbstractOptimizer(AbstractModule):
 
         return new_params
 
-    def generate_parameter(self) -> list[dict[str, float | int | str]] | None:
+    def generate_parameter(self) -> Any:
         """Generate a list of parameters.
 
         Raises:

--- a/aiaccel/optimizer/create.py
+++ b/aiaccel/optimizer/create.py
@@ -5,7 +5,7 @@ from importlib import import_module
 from aiaccel.config import Config
 
 
-def create_optimizer(config_path: str) -> type | None:
+def create_optimizer(config_path: str) -> type:
     """Returns master type.
 
     Args:
@@ -18,7 +18,7 @@ def create_optimizer(config_path: str) -> type | None:
     return import_and_getattr(config.search_algorithm.get())
 
 
-def import_and_getattr(name: str) -> type | None:
+def import_and_getattr(name: str) -> type:
     """Imports the specified Optimizer class.
 
     Args:

--- a/aiaccel/optimizer/create.py
+++ b/aiaccel/optimizer/create.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from typing import Any
+
 from importlib import import_module
 
 from aiaccel.config import Config
 
 
-def create_optimizer(config_path: str) -> type:
+def create_optimizer(config_path: str) -> Any:
     """Returns master type.
 
     Args:
@@ -18,7 +20,7 @@ def create_optimizer(config_path: str) -> type:
     return import_and_getattr(config.search_algorithm.get())
 
 
-def import_and_getattr(name: str) -> type:
+def import_and_getattr(name: str) -> Any:
     """Imports the specified Optimizer class.
 
     Args:

--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import math
 from functools import reduce
 from operator import mul
+from typing import Any
 
 from aiaccel.config import Config
 from aiaccel.optimizer.abstract_optimizer import AbstractOptimizer
@@ -11,7 +12,7 @@ from aiaccel.parameter import HyperParameter
 def get_grid_options(
     parameter_name: str,
     config: Config
-) -> tuple[int | None, bool, int | None]:
+) -> tuple[Any, bool, Any]:
     """Get options about grid search.
 
     Args:
@@ -59,7 +60,7 @@ def get_grid_options(
 
 def generate_grid_points(
     p: HyperParameter, config: Config
-) -> dict[str, float | int | str | list[float, int, str]]:
+) -> dict[str, Any]:
     """Make a list of all parameters for this grid.
 
     Args:
@@ -124,8 +125,8 @@ class GridOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.ready_params = None
-        self.generate_index = None
+        self.ready_params: list
+        self.generate_index: int
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.
@@ -185,7 +186,7 @@ class GridOptimizer(AbstractOptimizer):
             list[dict[str, float | int | str]]: A list of new parameters.
         """
         parameter_index = self.get_parameter_index()
-        new_params = []
+        new_params: list[Any] = []
 
         if parameter_index is None:
             self.logger.info('Generated all of parameters.')

--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -125,8 +125,8 @@ class GridOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.ready_params: list
-        self.generate_index: int
+        self.ready_params: Any = None
+        self.generate_index: Any = None
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -23,7 +23,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.nelder_mead: NelderMead
+        self.nelder_mead: Any = None
         self.parameter_pool: list[dict[str, Any]] = []
         self.order: list[Any] = []
 

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -53,7 +53,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
     def check_result(self) -> None:
         pass
 
-    def get_ready_parameters(self) -> list:
+    def get_ready_parameters(self) -> list[Any]:
         """Get the list of ready parameters.
 
         Returns:
@@ -61,7 +61,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
         """
         return self.nelder_mead._executing
 
-    def get_nm_results(self) -> list[dict[str, str | int | list | bool]]:
+    def get_nm_results(self) -> list[dict[str, str | int | list[Any] | bool]]:
         """ Get the list of Nelder-Mead result.
 
         Returns:
@@ -85,7 +85,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
 
         return nm_results
 
-    def _add_result(self, nm_results: list) -> None:
+    def _add_result(self, nm_results: list[Any]) -> None:
         """  Add a result parameter.
 
         Args:
@@ -159,7 +159,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
                 e['vertex_id'] = new_param_name
                 break
 
-    def nelder_mead_main(self) -> list | None:
+    def nelder_mead_main(self) -> list[Any] | None:
         """ Nelder Mead's main module.
 
         Args:
@@ -176,7 +176,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
             return None
         return searched_params
 
-    def _get_all_trial_id(self) -> list:
+    def _get_all_trial_id(self) -> list[Any]:
         """_get_all_trial_id.
 
         Get trial_ids from DB: 'result', 'finished', 'running', 'ready'
@@ -190,7 +190,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
 
         return trial_id
 
-    def _get_current_names(self) -> list:
+    def _get_current_names(self) -> list[Any]:
         """Get parameter trial_id.
 
         Returns:

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import copy
+from typing import Any
 
 from aiaccel.optimizer._nelder_mead import NelderMead
 from aiaccel.optimizer.abstract_optimizer import AbstractOptimizer
@@ -22,9 +23,9 @@ class NelderMeadOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.nelder_mead = None
-        self.parameter_pool = []
-        self.order = []
+        self.nelder_mead: NelderMead
+        self.parameter_pool: list[dict[str, Any]] = []
+        self.order: list[Any] = []
 
     def generate_initial_parameter(
         self
@@ -37,7 +38,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
         """
         initial_parameter = super().generate_initial_parameter()
         if self.nelder_mead is not None:
-            return
+            return None
 
         self.params = self.special_settings_when_using_ordinal(self.params)
 
@@ -109,8 +110,8 @@ class NelderMeadOptimizer(AbstractOptimizer):
 
     def update_ready_parameter_name(
         self,
-        pool_p: str,  # old_param_name
-        name: str     # new_param_name
+        pool_p: dict[str, Any],  # old_param_name
+        name: Any     # new_param_name
     ) -> None:
         """ Update hyperparameter's names.
 
@@ -158,7 +159,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
                 e['vertex_id'] = new_param_name
                 break
 
-    def nelder_mead_main(self) -> list:
+    def nelder_mead_main(self) -> list | None:
         """ Nelder Mead's main module.
 
         Args:
@@ -225,7 +226,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
             ):
                 self.parameter_pool.append(copy.copy(p))
 
-        new_params = []
+        new_params: list[Any] = []
 
         if len(self.parameter_pool) == 0:
             return new_params

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from scipy.stats import qmc
 
 from aiaccel.optimizer.abstract_optimizer import AbstractOptimizer
@@ -24,7 +26,7 @@ class SobolOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.generate_index: int
+        self.generate_index: Any = None
         self.sampler: qmc.Sobol
 
     def pre_process(self) -> None:

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -27,7 +27,7 @@ class SobolOptimizer(AbstractOptimizer):
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
         self.generate_index: Any = None
-        self.sampler: qmc.Sobol
+        self.sampler: Any = None
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -24,8 +24,8 @@ class SobolOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.generate_index = None
-        self.sampler = None
+        self.generate_index: int
+        self.sampler: qmc.Sobol
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import optuna
 
 import aiaccel.parameter
@@ -42,7 +44,7 @@ class TpeOptimizer(AbstractOptimizer):
         self.parameter_pool: dict = {}
         self.parameter_list: list = []
         self.study_name = "distributed-tpe"
-        self.study: optuna.Study
+        self.study: Any = None
         self.distributions: dict
         self.trial_pool: dict = {}
         self.randseed = self.config.randseed.get()

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -41,12 +41,12 @@ class TpeOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.parameter_pool: dict = {}
-        self.parameter_list: list = []
+        self.parameter_pool: dict[str, Any] = {}
+        self.parameter_list: list[Any] = []
         self.study_name = "distributed-tpe"
         self.study: Any = None
         self.distributions: Any = None
-        self.trial_pool: dict = {}
+        self.trial_pool: dict[str, Any] = {}
         self.randseed = self.config.randseed.get()
 
     def pre_process(self) -> None:
@@ -194,7 +194,7 @@ class TpeOptimizer(AbstractOptimizer):
 
 def create_distributions(
         parameters: aiaccel.parameter.HyperParameterConfiguration
-) -> dict:
+) -> dict[str, Any]:
     """Create an optuna.distributions dictionary for the parameters.
 
     Args:

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -39,12 +39,12 @@ class TpeOptimizer(AbstractOptimizer):
 
     def __init__(self, options: dict[str, str | int | bool]) -> None:
         super().__init__(options)
-        self.parameter_pool = {}
-        self.parameter_list = []
+        self.parameter_pool: dict = {}
+        self.parameter_list: list = []
         self.study_name = "distributed-tpe"
-        self.study = None
-        self.distributions = None
-        self.trial_pool = {}
+        self.study: optuna.Study
+        self.distributions: dict
+        self.trial_pool: dict = {}
         self.randseed = self.config.randseed.get()
 
     def pre_process(self) -> None:
@@ -206,7 +206,7 @@ def create_distributions(
     Returns:
         (dict): An optuna.distributions object.
     """
-    distributions = {}
+    distributions: dict[str, optuna.distributions.BaseDistribution] = {}
 
     for p in parameters.get_parameter_list():
         if p.type.lower() == 'float':

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -45,7 +45,7 @@ class TpeOptimizer(AbstractOptimizer):
         self.parameter_list: list = []
         self.study_name = "distributed-tpe"
         self.study: Any = None
-        self.distributions: dict
+        self.distributions: Any = None
         self.trial_pool: dict = {}
         self.randseed = self.config.randseed.get()
 

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -57,7 +57,7 @@ def get_best_parameter(files: list[Path], goal: str, dict_lock: Path
     return best, best_file
 
 
-def get_type(parameter: dict) -> str:
+def get_type(parameter: dict[str, Any]) -> str:
     """Get a type of a specified parameter.
 
     Args:
@@ -148,7 +148,7 @@ class HyperParameter(object):
         if 'base' in parameter:
             self.base = parameter['base']
 
-    def sample(self, initial: bool = False, rng: Any = None) -> dict:
+    def sample(self, initial: bool = False, rng: Any = None) -> dict[str, Any]:
         """Sample a parameter.
 
         Args:
@@ -189,7 +189,7 @@ class HyperParameterConfiguration(object):
         hps (dict): Hyper parameters.
     """
 
-    def __init__(self, json_string: dict) -> None:
+    def __init__(self, json_string: Any) -> None:
         self.json_string = json_string
         self.hps: dict[str, HyperParameter] = {}
 
@@ -221,7 +221,7 @@ class HyperParameterConfiguration(object):
         """
         return list(self.hps.values())
 
-    def get_parameter_dict(self) -> dict:
+    def get_parameter_dict(self) -> dict[str, Any]:
         """Get a dictionary of hyper parameters.
 
         Returns:
@@ -230,7 +230,7 @@ class HyperParameterConfiguration(object):
         return self.hps
 
     def sample(self, initial: bool = False, rng: Any = None
-               ) -> list[dict]:
+               ) -> list[dict[str, Any]]:
         """Sample a hyper parameters set.
 
         Args:
@@ -247,7 +247,7 @@ class HyperParameterConfiguration(object):
         return ret
 
 
-def load_parameter(json_string: dict) -> HyperParameterConfiguration:
+def load_parameter(json_string: dict[str, Any]) -> HyperParameterConfiguration:
     """Load HyperParameterConfiguration object from a configuration file.
 
     Args:

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -4,8 +4,6 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import numpy as np
-
 import aiaccel
 from aiaccel.util.filesystem import load_yaml
 

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -104,15 +105,15 @@ class HyperParameter(object):
         q (float | int): A quantization factor.
     """
 
-    def __init__(self, parameter: dict[str, bool | int | float | list]) -> None:
+    def __init__(self, parameter: dict[str, Any]) -> None:
         self._raw_dict = parameter
         self.name = parameter['name']
         self.type = get_type(parameter)
-        self.log = False
-        self.lower = None
-        self.upper = None
-        self.choices = None
-        self.sequence = None
+        self.log = parameter.get('log', False)
+        # self.lower = None
+        # self.upper = None
+        # self.choices = None
+        # self.sequence = None
         self.initial = None
         self.q = None
         self.step = None
@@ -120,17 +121,22 @@ class HyperParameter(object):
         if 'log' in parameter:
             self.log = parameter['log']
 
-        if 'lower' in parameter:
-            self.lower = parameter['lower']
+        # if 'upper' in parameter:
+        #     self.upper = parameter['lower']
 
-        if 'upper' in parameter:
-            self.upper = parameter['upper']
+        # if 'upper' in parameter:
+        #     self.upper = parameter['upper']
 
-        if 'choices' in parameter:
-            self.choices = parameter['choices']
+        # if 'choices' in parameter:
+        #     self.choices = parameter['choices']
 
-        if 'sequence' in parameter:
-            self.sequence = parameter['sequence']
+        # if 'sequence' in parameter:
+        #     self.sequence = parameter['sequence']
+
+        self.lower = parameter.get('lower', None)
+        self.upper = parameter.get('upper', None)
+        self.choices = parameter.get('choices', None)
+        self.sequence = parameter.get('sequence', None)
 
         if 'initial' in parameter:
             self.initial = parameter['initial']
@@ -144,7 +150,7 @@ class HyperParameter(object):
         if 'base' in parameter:
             self.base = parameter['base']
 
-    def sample(self, initial: bool = False, rng: np.random.RandomState = None) -> dict:
+    def sample(self, initial: bool = False, rng: Any = None) -> dict:
         """Sample a parameter.
 
         Args:
@@ -225,7 +231,7 @@ class HyperParameterConfiguration(object):
         """
         return self.hps
 
-    def sample(self, initial: bool = False, rng: np.random.RandomState = None
+    def sample(self, initial: bool = False, rng: Any = None
                ) -> list[dict]:
         """Sample a hyper parameters set.
 

--- a/aiaccel/scheduler/abci_scheduler.py
+++ b/aiaccel/scheduler/abci_scheduler.py
@@ -51,7 +51,10 @@ class AbciScheduler(AbstractScheduler):
         numbers = re.compile(r'\d{1,65535}')
         if full.search(command) is None:
             return None
-        return numbers.search(command).group()
+        if match := numbers.search(command):
+            return match.group()
+        else:
+            return None
 
     def create_model(self) -> AbciModel:
         """Creates model object of state machine.

--- a/aiaccel/scheduler/abci_scheduler.py
+++ b/aiaccel/scheduler/abci_scheduler.py
@@ -22,8 +22,8 @@ class AbciScheduler(AbstractScheduler):
 
         commands = 'qstat -xml'
         p = subprocess.Popen(commands, stdout=subprocess.PIPE, shell=True)
-        stats = p.communicate()[0]
-        stats = stats.decode('utf-8')
+        stdout_data, _ = p.communicate()
+        stats = stdout_data.decode('utf-8')
 
         if len(stats) < 1:
             return

--- a/aiaccel/scheduler/abstract_scheduler.py
+++ b/aiaccel/scheduler/abstract_scheduler.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from aiaccel.module import AbstractModule
-from aiaccel.scheduler.algorithm import schedule_sampling
+from aiaccel.scheduler.algorithm.schedule_sampling import RandomSampling
+from aiaccel.scheduler.algorithm.abstract_scheduling_algorithm import AbstractSchedulingAlgorithm
 from aiaccel.scheduler.job.job import Job
 from aiaccel.scheduler.job.model.abstract_model import AbstractModel
 from aiaccel.scheduler.job.model.local_model import LocalModel
@@ -49,10 +51,10 @@ class AbstractScheduler(AbstractModule):
 
         self.max_resource = self.config.num_node.get()
         self.available_resource = self.max_resource
-        self.stats = []
-        self.jobs = []
-        self.job_status = {}
-        self.algorithm = None
+        self.stats: list[Any] = []
+        self.jobs: list[Any] = []
+        self.job_status: dict[Any, Any] = {}
+        self.algorithm: AbstractSchedulingAlgorithm
         self.num_node = self.config.num_node.get()
 
     def change_state_finished_trials(self) -> None:
@@ -137,7 +139,7 @@ class AbstractScheduler(AbstractModule):
         self.create_numpy_random_generator()
         self.resume()
 
-        self.algorithm = schedule_sampling.RandomSampling(self.config)
+        self.algorithm = RandomSampling(self.config)
         self.change_state_finished_trials()
 
         runnings = self.storage.trial.get_running()
@@ -209,7 +211,7 @@ class AbstractScheduler(AbstractModule):
 
         return True
 
-    def parse_trial_id(self, command: str) -> str:
+    def parse_trial_id(self, command: str) -> str | None:
         """Parse a command string and extract an unique name.
 
         Args:

--- a/aiaccel/scheduler/abstract_scheduler.py
+++ b/aiaccel/scheduler/abstract_scheduler.py
@@ -82,7 +82,7 @@ class AbstractScheduler(AbstractModule):
         """
         self.get_each_state_count()
 
-    def start_job(self, trial_id: int) -> Job | None:
+    def start_job(self, trial_id: int) -> Any:
         """Start a new job.
 
         Args:
@@ -319,7 +319,7 @@ class AbstractScheduler(AbstractModule):
         del obj['jobs']
         return obj
 
-    def create_model(self) -> AbstractModel | None:
+    def create_model(self) -> Any:
         """Creates model object of state machine.
 
         Override with a Scheduler that uses a Model.

--- a/aiaccel/scheduler/abstract_scheduler.py
+++ b/aiaccel/scheduler/abstract_scheduler.py
@@ -32,7 +32,7 @@ class AbstractScheduler(AbstractModule):
             command or qstat command.
     """
 
-    def __init__(self, options: dict) -> None:
+    def __init__(self, options: dict[str, Any]) -> None:
         self.options = options
         self.options['process_name'] = 'scheduler'
         super().__init__(self.options)
@@ -312,7 +312,7 @@ class AbstractScheduler(AbstractModule):
         result_file_path = self.ws / dict_result / file_name
         create_yaml(result_file_path, content)
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         obj = super().__getstate__()
         del obj['jobs']
         return obj

--- a/aiaccel/scheduler/abstract_scheduler.py
+++ b/aiaccel/scheduler/abstract_scheduler.py
@@ -7,7 +7,6 @@ from aiaccel.module import AbstractModule
 from aiaccel.scheduler.algorithm.schedule_sampling import RandomSampling
 from aiaccel.scheduler.algorithm.abstract_scheduling_algorithm import AbstractSchedulingAlgorithm
 from aiaccel.scheduler.job.job import Job
-from aiaccel.scheduler.job.model.abstract_model import AbstractModel
 from aiaccel.scheduler.job.model.local_model import LocalModel
 from aiaccel.util.logger import str_to_logging_level
 from aiaccel.util.filesystem import create_yaml

--- a/aiaccel/scheduler/abstract_scheduler.py
+++ b/aiaccel/scheduler/abstract_scheduler.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from aiaccel.module import AbstractModule
 from aiaccel.scheduler.algorithm.schedule_sampling import RandomSampling
-from aiaccel.scheduler.algorithm.abstract_scheduling_algorithm import AbstractSchedulingAlgorithm
 from aiaccel.scheduler.job.job import Job
 from aiaccel.scheduler.job.model.local_model import LocalModel
 from aiaccel.util.logger import str_to_logging_level
@@ -53,7 +52,7 @@ class AbstractScheduler(AbstractModule):
         self.stats: list[Any] = []
         self.jobs: list[Any] = []
         self.job_status: dict[Any, Any] = {}
-        self.algorithm: AbstractSchedulingAlgorithm
+        self.algorithm: Any = None
         self.num_node = self.config.num_node.get()
 
     def change_state_finished_trials(self) -> None:

--- a/aiaccel/scheduler/algorithm/abstract_scheduling_algorithm.py
+++ b/aiaccel/scheduler/algorithm/abstract_scheduling_algorithm.py
@@ -23,7 +23,7 @@ class AbstractSchedulingAlgorithm(object):
         hp_ready: list[Path],
         num: int = 1,
         rng: np.random.RandomState | None = None
-    ) -> None:
+    ) -> list[Path]:
         """Select multiple hyper parameters.
 
         Args:

--- a/aiaccel/scheduler/algorithm/random_sampling.py
+++ b/aiaccel/scheduler/algorithm/random_sampling.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
-import numpy as np
+
 from pathlib import Path
+from typing import Any
+
+import numpy as np
 
 from aiaccel.scheduler.algorithm.abstract_scheduling_algorithm import \
     AbstractSchedulingAlgorithm
@@ -15,7 +18,7 @@ class RandomSamplingSchedulingAlgorithm(AbstractSchedulingAlgorithm):
         self,
         hp_ready: list[Path],
         num: int = 1,
-        rng: np.random.RandomState | None = None
+        rng: Any = None
     ) -> list[Path]:
         """Select multiple hyper parameters.
 

--- a/aiaccel/scheduler/algorithm/random_sampling.py
+++ b/aiaccel/scheduler/algorithm/random_sampling.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import numpy as np
-
 from aiaccel.scheduler.algorithm.abstract_scheduling_algorithm import \
     AbstractSchedulingAlgorithm
 

--- a/aiaccel/scheduler/algorithm/schedule_sampling.py
+++ b/aiaccel/scheduler/algorithm/schedule_sampling.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import numpy as np
 from pathlib import Path
 from typing import Any
 

--- a/aiaccel/scheduler/algorithm/schedule_sampling.py
+++ b/aiaccel/scheduler/algorithm/schedule_sampling.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from pathlib import Path
+from typing import Any
 
 from aiaccel.scheduler.algorithm.abstract_scheduling_algorithm import \
     AbstractSchedulingAlgorithm
@@ -12,7 +13,7 @@ class RandomSampling(AbstractSchedulingAlgorithm):
         self,
         hp_ready: list[Path],
         num: int = 1,
-        rng: np.random.RandomState | None = None
+        rng: Any = None
     ) -> list[Path]:
         """Select multiple hyper parameters.
 
@@ -41,7 +42,7 @@ class SequentialSampling(AbstractSchedulingAlgorithm):
         self,
         hp_ready: list[Path],               # A list of path of ready hyper parameters.
         num: int = 1,             # A number to select hyper parameters.
-        rng: np.random.RandomState | None = None   # A random generator.
+        rng: Any = None   # A random generator.
     ) -> list[Path]:
         """Select multiple hyper parameters.
 

--- a/aiaccel/scheduler/create.py
+++ b/aiaccel/scheduler/create.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
+from typing import Any
+
 from aiaccel.config import Config
 from aiaccel.scheduler.abci_scheduler import AbciScheduler
 from aiaccel.scheduler.local_scheduler import LocalScheduler
 from aiaccel.scheduler.pylocal_scheduler import PylocalScheduler
 
 
-def create_scheduler(config_path: str) -> type:
+def create_scheduler(config_path: str) -> Any:
     """Returns scheduler type.
 
     Args:
         config_path (str): Path to configuration file.
 
     Returns:
-        type: `LocalScheduler`, `PylocalScheduler`, or `AbciScheduler`
+        type | None: `LocalScheduler`, `PylocalScheduler`, or `AbciScheduler`
             if resource type is 'local', 'python_local', or 'abci',
-            respectively.
+            respectively. Other cases, None.
     """
     config = Config(config_path)
     resource = config.resource_type.get()
@@ -30,4 +32,4 @@ def create_scheduler(config_path: str) -> type:
         return AbciScheduler
 
     else:
-        raise ValueError("Resource type is 'local', 'python_local', or 'abci'")
+        return None

--- a/aiaccel/scheduler/create.py
+++ b/aiaccel/scheduler/create.py
@@ -6,16 +6,16 @@ from aiaccel.scheduler.local_scheduler import LocalScheduler
 from aiaccel.scheduler.pylocal_scheduler import PylocalScheduler
 
 
-def create_scheduler(config_path: str) -> type | None:
+def create_scheduler(config_path: str) -> type:
     """Returns scheduler type.
 
     Args:
         config_path (str): Path to configuration file.
 
     Returns:
-        type | None: `LocalScheduler`, `PylocalScheduler`, or `AbciScheduler`
+        type: `LocalScheduler`, `PylocalScheduler`, or `AbciScheduler`
             if resource type is 'local', 'python_local', or 'abci',
-            respectively. Other cases, None.
+            respectively.
     """
     config = Config(config_path)
     resource = config.resource_type.get()
@@ -30,4 +30,4 @@ def create_scheduler(config_path: str) -> type | None:
         return AbciScheduler
 
     else:
-        return None
+        raise ValueError("Resource type is 'local', 'python_local', or 'abci'")

--- a/aiaccel/scheduler/job/job.py
+++ b/aiaccel/scheduler/job/job.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
-
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from subprocess import Popen
+from typing import Any
 from typing import TYPE_CHECKING
 
 from transitions import Machine
@@ -13,6 +15,7 @@ from aiaccel import dict_lock
 from aiaccel import dict_result
 from aiaccel import dict_error
 from aiaccel.util.buffer import Buffer
+from aiaccel.util.process import OutputHandler
 from aiaccel.util.time_tools import get_time_now_object
 from aiaccel.util.trialid import TrialId
 from aiaccel.scheduler.job.model.abci_model import AbciModel
@@ -538,7 +541,6 @@ class Job:
         super(Job, self).__init__()
         # === Load config file===
         self.config = config
-        self.config_path = self.config.config_path
         # === Get config parameter values ===
         self.workspace = self.config.workspace.get()
         self.cancel_retry = self.config.cancel_retry.get()
@@ -560,7 +562,7 @@ class Job:
         self.running_timeout = self.config.running_timeout.get()
         self.resource_type = self.config.resource_type.get()
 
-        self.threshold_timeout = None
+        self.threshold_timeout: datetime | None
         self.threshold_retry = None
         self.count_retry = 0
 
@@ -587,14 +589,14 @@ class Job:
         )
         self.loop_count = 0
 
-        self.config_path = str(self.config_path)
+        self.config_path = str(self.config.config_path)
         self.trial_id = trial_id
         self.trial_id_str = TrialId(self.config_path).zero_padding_any_trial_id(self.trial_id)
-        self.from_file = None
-        self.to_file = None
-        self.next_state = None
-        self.proc = None
-        self.th_oh = None
+        self.from_file: Path | None
+        self.to_file: Path | None
+        self.next_state: str
+        self.proc: Popen
+        self.th_oh: OutputHandler
         self.stop_flag = False
         self.storage = Storage(self.ws)
         self.content = self.storage.get_hp_dict(self.trial_id)
@@ -624,7 +626,7 @@ class Job:
         """
         return self.model
 
-    def get_state(self) -> Machine:
+    def get_state(self) -> Any:
         """Get a current state.
 
         Returns:

--- a/aiaccel/scheduler/job/job.py
+++ b/aiaccel/scheduler/job/job.py
@@ -22,8 +22,8 @@ from aiaccel.scheduler.job.model.abci_model import AbciModel
 from aiaccel.scheduler.job.model.local_model import LocalModel
 
 if TYPE_CHECKING:  # pragma: no cover
-    from aiaccel.scheduler.abci_scheduler import AbciScheduler
-    from aiaccel.scheduler.local_scheduler import LocalScheduler
+    from aiaccel.scheduler.abstract_scheduler import AbstractScheduler
+    from aiaccel.scheduler.job.model.abstract_model import AbstractModel
 
 from aiaccel.config import Config
 from aiaccel.storage.storage import Storage
@@ -76,7 +76,7 @@ JOB_STATES = [
     {'name': 'Success'},
 ]
 
-JOB_TRANSITIONS = [
+JOB_TRANSITIONS: list[dict[str, str | list[str]]] = [
     {
         'trigger': 'next',
         'source': 'Init',
@@ -534,8 +534,8 @@ class Job:
     def __init__(
         self,
         config: Config,
-        scheduler: AbciScheduler | LocalScheduler,
-        model: AbciModel | LocalModel,
+        scheduler: AbstractScheduler,
+        model: AbstractModel,
         trial_id: int
     ) -> None:
         super(Job, self).__init__()
@@ -593,7 +593,7 @@ class Job:
         self.trial_id = trial_id
         self.trial_id_str = TrialId(self.config_path).zero_padding_any_trial_id(self.trial_id)
         self.from_file: Path | None
-        self.to_file: Path | None
+        self.to_file: Any
         self.next_state: str
         self.proc: Popen
         self.th_oh: OutputHandler
@@ -618,7 +618,7 @@ class Job:
         """
         return self.machine
 
-    def get_model(self) -> AbciModel | LocalModel:
+    def get_model(self) -> AbstractModel:
         """Get a state transition model object.
 
         Returns:

--- a/aiaccel/scheduler/job/job.py
+++ b/aiaccel/scheduler/job/job.py
@@ -4,7 +4,6 @@ import logging
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from subprocess import Popen
 from typing import Any
 from typing import TYPE_CHECKING
 
@@ -15,11 +14,8 @@ from aiaccel import dict_lock
 from aiaccel import dict_result
 from aiaccel import dict_error
 from aiaccel.util.buffer import Buffer
-from aiaccel.util.process import OutputHandler
 from aiaccel.util.time_tools import get_time_now_object
 from aiaccel.util.trialid import TrialId
-from aiaccel.scheduler.job.model.abci_model import AbciModel
-from aiaccel.scheduler.job.model.local_model import LocalModel
 
 if TYPE_CHECKING:  # pragma: no cover
     from aiaccel.scheduler.abstract_scheduler import AbstractScheduler
@@ -562,7 +558,7 @@ class Job:
         self.running_timeout = self.config.running_timeout.get()
         self.resource_type = self.config.resource_type.get()
 
-        self.threshold_timeout: datetime | None
+        self.threshold_timeout: datetime | None = None
         self.threshold_retry = None
         self.count_retry = 0
 
@@ -592,11 +588,11 @@ class Job:
         self.config_path = str(self.config.config_path)
         self.trial_id = trial_id
         self.trial_id_str = TrialId(self.config_path).zero_padding_any_trial_id(self.trial_id)
-        self.from_file: Path | None
-        self.to_file: Any
-        self.next_state: str
-        self.proc: Popen
-        self.th_oh: OutputHandler
+        self.from_file: Any = None
+        self.to_file: Any = None
+        self.next_state: Any = None
+        self.proc: Any = None
+        self.th_oh: Any = None
         self.stop_flag = False
         self.storage = Storage(self.ws)
         self.content = self.storage.get_hp_dict(self.trial_id)

--- a/aiaccel/scheduler/job/model/abci_model.py
+++ b/aiaccel/scheduler/job/model/abci_model.py
@@ -44,7 +44,7 @@ class AbciModel(AbstractModel):
         runner_file = self.get_runner_file(obj)
         runner_command = create_qsub_command(
             obj.config,
-            str(runner_file)
+            runner_file
         )
 
         obj.logger.info(f'runner command: {" ".join(runner_command)}')

--- a/aiaccel/scheduler/job/model/abstract_model.py
+++ b/aiaccel/scheduler/job/model/abstract_model.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
 from collections.abc import Callable
+from pathlib import Path
+from typing import Any
 
 from aiaccel import dict_runner
 from aiaccel.util.filesystem import create_yaml
@@ -15,9 +16,9 @@ if TYPE_CHECKING:
 
 class AbstractModel(object):
     state: str
-    expire: Callable
-    schedule: Callable
-    next: Callable
+    expire: Callable[[Any], Any]
+    schedule: Callable[[Any], Any]
+    next: Callable[[Any], Any]
 
     # Common
 
@@ -407,5 +408,5 @@ class AbstractModel(object):
         )
         obj.threshold_retry = obj.expire_retry
 
-    def change_state(self, obj: 'Job'):
+    def change_state(self, obj: 'Job') -> None:
         obj.storage.trial.set_any_trial_state(trial_id=obj.trial_id, state=obj.next_state)

--- a/aiaccel/scheduler/job/model/abstract_model.py
+++ b/aiaccel/scheduler/job/model/abstract_model.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+from collections.abc import Callable
 
 from aiaccel import dict_runner
 from aiaccel.util.filesystem import create_yaml
@@ -12,8 +14,13 @@ if TYPE_CHECKING:
 
 
 class AbstractModel(object):
+    state: str
+    expire: Callable
+    schedule: Callable
+    next: Callable
 
     # Common
+
     def after_confirmed(self, obj: 'Job') -> None:
         """State transition of 'after_confirmed'.
 
@@ -71,11 +78,11 @@ class AbstractModel(object):
         """
         obj.storage.trial.set_any_trial_state(
             trial_id=obj.trial_id,
-            state=obj.next_trial_state
+            state=obj.next_state
         )
         return
 
-    def get_runner_file(self, obj: 'Job') -> None:
+    def get_runner_file(self, obj: 'Job') -> Path:
         return obj.ws / dict_runner / f'run_{obj.trial_id_str}.sh'
 
     # Runner

--- a/aiaccel/scheduler/local_scheduler.py
+++ b/aiaccel/scheduler/local_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from aiaccel.scheduler.abstract_scheduler import AbstractScheduler
 from aiaccel.util.process import ps2joblist
@@ -34,7 +35,7 @@ class LocalScheduler(AbstractScheduler):
                 else:
                     self.logger.warning(f'**** Unknown process: {r}')
 
-    def parse_trial_id(self, command: str) -> str | None:
+    def parse_trial_id(self, command: str) -> Any:
         """Parse a command string and extract an unique name.
 
         Args:

--- a/aiaccel/scheduler/pylocal_scheduler.py
+++ b/aiaccel/scheduler/pylocal_scheduler.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from multiprocessing.pool import Pool, ThreadPool
-import importlib
+from importlib.util import spec_from_file_location
+from importlib.util import module_from_spec
 from pathlib import Path
+from typing import Any
 
 from aiaccel.scheduler.abstract_scheduler import AbstractScheduler
 from aiaccel.util.aiaccel import Run
@@ -11,6 +13,13 @@ from aiaccel.util.aiaccel import set_logging_file_for_trial_id
 from aiaccel.util.time_tools import get_time_now
 from aiaccel.util.cast import cast_y
 from aiaccel.config import Config
+
+
+# These are for avoiding mypy-errors from initializer().
+# `global` does not work well.
+# https://github.com/python/mypy/issues/5732
+user_func: Any
+workspace: Path
 
 
 class PylocalScheduler(AbstractScheduler):
@@ -73,12 +82,14 @@ def initializer(config_path: str | Path):
     config = Config(config_path)
 
     # Load the specified module from the specified python program.
-    spec = importlib.util.spec_from_file_location("user_module", config.python_file.get())
-    module = importlib.util.module_from_spec(spec)
+    spec = spec_from_file_location("user_module", config.python_file.get())
+    if spec is None:
+        raise ValueError("Invalid python_path.")
+    module = module_from_spec(spec)
+    if spec.loader is None:
+        raise ValueError("spec.loader not defined.")
     spec.loader.exec_module(module)
-
     user_func = getattr(module, config.function.get())
-
     workspace = Path(config.workspace.get()).resolve()
 
 

--- a/aiaccel/scheduler/pylocal_scheduler.py
+++ b/aiaccel/scheduler/pylocal_scheduler.py
@@ -27,7 +27,7 @@ class PylocalScheduler(AbstractScheduler):
 
     """
 
-    def __init__(self, options: dict) -> None:
+    def __init__(self, options: dict[str, Any]) -> None:
         super().__init__(options)
         self.run = Run(self.config_path)
         self.com = WrapperInterface()
@@ -61,7 +61,7 @@ class PylocalScheduler(AbstractScheduler):
 
         return True
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         obj = super().__getstate__()
         del obj['run']
         del obj['pool']
@@ -76,7 +76,7 @@ class PylocalScheduler(AbstractScheduler):
         return None
 
 
-def initializer(config_path: str | Path):
+def initializer(config_path: str | Path) -> None:
     global user_func, workspace
 
     config = Config(config_path)
@@ -93,7 +93,7 @@ def initializer(config_path: str | Path):
     workspace = Path(config.workspace.get()).resolve()
 
 
-def execute(args):
+def execute(args: Any) -> Any:
     trial_id, xs = args
 
     start_time = get_time_now()

--- a/aiaccel/storage/abstract.py
+++ b/aiaccel/storage/abstract.py
@@ -13,7 +13,7 @@ from aiaccel.util.retry import retry
 class Abstract:
 
     @retry(_MAX_NUM=6, _DELAY=1.0)
-    def __init__(self, file_name: Path):
+    def __init__(self, file_name: Path) -> None:
         self.url = f'sqlite:///{file_name}'
         self.engine = create_engine(
             self.url,

--- a/aiaccel/storage/error.py
+++ b/aiaccel/storage/error.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+
 from sqlalchemy.exc import SQLAlchemyError
 
 from aiaccel.storage.abstract import Abstract
@@ -66,7 +68,7 @@ class Error(Abstract):
         return data.error
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def get_error_trial_id(self) -> list:
+    def get_error_trial_id(self) -> list[Any]:
         """Obtain a list of trial ids in which an error occurred.
 
         Returns:

--- a/aiaccel/storage/hp.py
+++ b/aiaccel/storage/hp.py
@@ -66,7 +66,7 @@ class Hp(Abstract):
                 raise e
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def get_any_trial_params(self, trial_id: int) -> list[HpTable] | None:
+    def get_any_trial_params(self, trial_id: Any) -> list[HpTable] | None:
         """ Obtain the set parameter information for any given trial.
 
         Args:

--- a/aiaccel/storage/hp.py
+++ b/aiaccel/storage/hp.py
@@ -48,7 +48,7 @@ class Hp(Abstract):
                 raise e
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def set_any_trial_params(self, trial_id: int, params: list) -> None:
+    def set_any_trial_params(self, trial_id: int, params: list[dict[str, Any]]) -> None:
         with self.create_session() as session:
             try:
                 hps = [

--- a/aiaccel/storage/jobstate.py
+++ b/aiaccel/storage/jobstate.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+
 from sqlalchemy.exc import SQLAlchemyError
 
 from aiaccel.storage.abstract import Abstract
@@ -45,7 +47,7 @@ class JobState(Abstract):
                 raise e
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def set_any_trial_jobstates(self, states: list) -> None:
+    def set_any_trial_jobstates(self, states: list[Any]) -> None:
         """Set the specified jobstate to the specified trial.
 
         Args:
@@ -92,7 +94,7 @@ class JobState(Abstract):
         return data.state
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def get_all_trial_jobstate(self) -> list:
+    def get_all_trial_jobstate(self) -> list[Any]:
         with self.create_session() as session:
             data = (
                 session.query(JobStateTable)

--- a/aiaccel/storage/result.py
+++ b/aiaccel/storage/result.py
@@ -70,7 +70,7 @@ class Result(Abstract):
         return data.objective
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def get_all_result(self) -> list:
+    def get_all_result(self) -> list[Any]:
         """Get all results
 
         Returns:
@@ -85,7 +85,7 @@ class Result(Abstract):
         # return [d.objective for d in data]
         return data
 
-    def get_objectives(self) -> list:
+    def get_objectives(self) -> list[Any]:
         """Get all results in list.
 
         Returns:
@@ -95,7 +95,7 @@ class Result(Abstract):
 
         return [d.objective for d in data]
 
-    def get_bests(self, goal: str) -> list:
+    def get_bests(self, goal: str) -> list[Any]:
         """Obtains the sorted result.
 
         Returns:
@@ -123,7 +123,7 @@ class Result(Abstract):
         return best_values
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def get_result_trial_id_list(self) -> list | None:
+    def get_result_trial_id_list(self) -> list[Any] | None:
         """Obtains the sorted result.
 
         Returns:

--- a/aiaccel/storage/storage.py
+++ b/aiaccel/storage/storage.py
@@ -124,7 +124,7 @@ class Storage:
         """
         return trial_id in self.trial.get_finished()
 
-    def get_hp_dict(self, trial_id: Any) -> dict | None:
+    def get_hp_dict(self, trial_id: Any) -> Any:
         """Obtain information on a specified trial in dict.
 
         Args:
@@ -214,7 +214,7 @@ class Storage:
 
         return best_trial_id, best_value
 
-    def get_best_trial_dict(self, goal: str) -> dict | None:
+    def get_best_trial_dict(self, goal: str) -> Any:
         """Get best trial information in dict format.
 
         Args:

--- a/aiaccel/storage/storage.py
+++ b/aiaccel/storage/storage.py
@@ -43,7 +43,7 @@ class Storage:
 
         return max(trial_ids)
 
-    def get_ready(self) -> list:
+    def get_ready(self) -> list[Any]:
         """Get a trial number for the ready state.
 
         Returns:
@@ -51,7 +51,7 @@ class Storage:
         """
         return self.trial.get_ready()
 
-    def get_running(self) -> list:
+    def get_running(self) -> list[Any]:
         """Get a trial number for the running state.
 
         Returns:
@@ -59,7 +59,7 @@ class Storage:
         """
         return self.trial.get_running()
 
-    def get_finished(self) -> list:
+    def get_finished(self) -> list[Any]:
         """Get a trial number for the finished state.
 
         Returns:
@@ -165,7 +165,7 @@ class Storage:
         end_time = self.timestamp.get_any_trial_end_time(trial_id=trial_id)
         error = self.error.get_any_trial_error(trial_id=trial_id)
 
-        content: dict[str, str | int | float | list] = {}
+        content: dict[str, str | int | float | list[Any]] = {}
         content['trial_id'] = trial_id
         content['parameters'] = hp
         content['result'] = result
@@ -226,7 +226,7 @@ class Storage:
         best_trial_id, _ = self.get_best_trial(goal)
         return self.get_hp_dict(best_trial_id)
 
-    def get_result_and_error(self, trial_id: int) -> tuple:
+    def get_result_and_error(self, trial_id: int) -> tuple[Any, Any]:
         """Get results and errors for a given trial number.
 
         Args:

--- a/aiaccel/storage/storage.py
+++ b/aiaccel/storage/storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import aiaccel
 from aiaccel.storage.error import Error
@@ -123,7 +124,7 @@ class Storage:
         """
         return trial_id in self.trial.get_finished()
 
-    def get_hp_dict(self, trial_id: int) -> dict | None:
+    def get_hp_dict(self, trial_id: Any) -> dict | None:
         """Obtain information on a specified trial in dict.
 
         Args:
@@ -209,9 +210,9 @@ class Storage:
                     best_trial_id = trial_id
 
             else:
-                return (None, None)
+                return None, None
 
-        return (best_trial_id, best_value)
+        return best_trial_id, best_value
 
     def get_best_trial_dict(self, goal: str) -> dict | None:
         """Get best trial information in dict format.

--- a/aiaccel/storage/timestamp.py
+++ b/aiaccel/storage/timestamp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -139,7 +140,7 @@ class TimeStamp(Abstract):
                 raise e
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def delete_any_trial_timestamp(self, trial_id) -> None:
+    def delete_any_trial_timestamp(self, trial_id: Any) -> None:
         with self.create_session() as session:
             try:
                 session.query(TimestampTable).filter(TimestampTable.trial_id == trial_id).delete()

--- a/aiaccel/storage/trial.py
+++ b/aiaccel/storage/trial.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from sqlalchemy.exc import SQLAlchemyError
+from pathlib import Path
+from typing import Any
 from typing import Literal
+
+from sqlalchemy.exc import SQLAlchemyError
 
 from aiaccel.storage.abstract import Abstract
 from aiaccel.storage.model import TrialTable
@@ -9,7 +12,7 @@ from aiaccel.util.retry import retry
 
 
 class Trial(Abstract):
-    def __init__(self, file_name) -> None:
+    def __init__(self, file_name: Path) -> None:
         super().__init__(file_name)
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
@@ -151,7 +154,7 @@ class Trial(Abstract):
         return [trial.trial_id for trial in trials]
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def get_finished(self) -> list:
+    def get_finished(self) -> list[Any]:
         """Get the trial id whose status is finished.
 
         Returns:

--- a/aiaccel/storage/variable.py
+++ b/aiaccel/storage/variable.py
@@ -102,7 +102,7 @@ class Variable(Abstract):
 class Value(Variable):
     def __init__(self, file_name: Path, label: str) -> None:
         super().__init__(file_name)
-        self.process_name: str
+        self.process_name: Any = None
         self.label = label
         self.value = None
 

--- a/aiaccel/storage/variable.py
+++ b/aiaccel/storage/variable.py
@@ -23,7 +23,7 @@ class Variable(Abstract):
         label: str,
         value: Any,
         update_allow: bool
-    ):
+    ) -> None:
         with self.create_session() as session:
             try:
                 query = (
@@ -54,7 +54,7 @@ class Variable(Abstract):
                 raise e
 
     @retry(_MAX_NUM=60, _DELAY=1.0)
-    def get_any_trial_variable(self, trial_id: int, process_name: str, label: str):
+    def get_any_trial_variable(self, trial_id: int, process_name: str, label: str) -> Any:
         with self.create_session() as session:
             data = (
                 session.query(VariableTable)
@@ -139,13 +139,13 @@ class Serializer:
         self.file_name: Path = file_name
         self.d: dict[str, Value] = {}
 
-    def register(self, process_name: str, labels: list) -> None:
+    def register(self, process_name: str, labels: list[str]) -> None:
         for i in range(len(labels)):
             if labels[i] not in self.d.keys():
                 self.d[labels[i]] = Value(self.file_name, labels[i])
                 self.d[labels[i]].set_process_name(process_name)
 
-    def delete_any_trial_variable(self, trial_id) -> None:
+    def delete_any_trial_variable(self, trial_id: int) -> None:
         for key in self.d.keys():
             self.d[key].delete(trial_id)
 

--- a/aiaccel/storage/variable.py
+++ b/aiaccel/storage/variable.py
@@ -102,7 +102,7 @@ class Variable(Abstract):
 class Value(Variable):
     def __init__(self, file_name: Path, label: str) -> None:
         super().__init__(file_name)
-        self.process_name = None
+        self.process_name: str
         self.label = label
         self.value = None
 

--- a/aiaccel/util/aiaccel.py
+++ b/aiaccel/util/aiaccel.py
@@ -311,7 +311,7 @@ class Run:
 
         return commands
 
-    def get_any_trial_xs(self, trial_id: int) -> dict | None:
+    def get_any_trial_xs(self, trial_id: int) -> Any:
         """Gets a parameter list of specific trial ID from Storage object.
 
         Args:

--- a/aiaccel/util/aiaccel.py
+++ b/aiaccel/util/aiaccel.py
@@ -35,7 +35,7 @@ class _Message:
         self.outputs: list[str] = []
         self.delimiter = "@"
 
-    def create_message(self, message: Any):
+    def create_message(self, message: Any) -> None:
         """ Concatenates a label and a message.
 
         Args:
@@ -91,12 +91,12 @@ class _Message:
             target_data.append("")
         return target_data
 
-    def clear(self):
+    def clear(self) -> None:
         self.outputs = []
 
 
 class Messages:
-    def __init__(self, *labels) -> None:
+    def __init__(self, *labels: Any) -> None:
         list_of_labels = list(labels)
         self.d: dict[str, _Message] = {}
         for label in list_of_labels:
@@ -154,13 +154,13 @@ class WrapperInterface:
                     "objective_err: err" -> err
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.stdout = Messages(
             "objective_y",
             "objective_err"
         )
 
-    def get_data(self, output: subprocess.CompletedProcess[bytes]) -> tuple:
+    def get_data(self, output: subprocess.CompletedProcess[bytes]) -> tuple[Any, Any]:
         """For wrapper side, gets stdout and stderr of user program.
 
         Args:
@@ -192,7 +192,7 @@ class WrapperInterface:
 
     def out(
         self,
-        objective_y: float | int | str | None = None,
+        objective_y: Any | None = None,
         objective_err: str | None = None
     ) -> None:
         """For user program side, outputs the objective value and error message
@@ -337,7 +337,7 @@ class Run:
         func: Callable[[Any], Any],
         trial_id: int,
         y_data_type: str | None
-    ) -> tuple:
+    ) -> Any:
         """Executes the target function.
 
         Args:
@@ -366,7 +366,7 @@ class Run:
         return xs, y, err
 
     @execute.register
-    def _(self, command: str, trial_id: int, y_data_type: str) -> tuple:
+    def _(self, command: str, trial_id: int, y_data_type: str) -> Any:
         """ Executes the user program.
 
         Args:
@@ -462,7 +462,7 @@ class Run:
         self.report(self.trial_id, xs, y, err, start_time, end_time)
 
     def report(
-        self, trial_id: int, xs: dict, y: Any, err: str, start_time: str,
+        self, trial_id: int, xs: dict[str, Any], y: Any, err: str, start_time: str,
         end_time: str
     ) -> None:
         """Saves results in the Storage object.
@@ -482,7 +482,7 @@ class Run:
             self.storage.error.set_any_trial_error(trial_id, err)
 
 
-def set_logging_file_for_trial_id(workspace, trial_id):
+def set_logging_file_for_trial_id(workspace: Path, trial_id: int) -> None:
     log_dir = workspace / "log"
     log_path = log_dir / f"job_{trial_id}.log"
     if not log_dir.exists():

--- a/aiaccel/util/aiaccel.py
+++ b/aiaccel/util/aiaccel.py
@@ -440,7 +440,7 @@ class Run:
         self.report(self.trial_id, xs, y, err, start_time, end_time)
 
     @execute_and_report.register
-    def _(self, command: str, y_data_type: str | None = None) -> None:
+    def _(self, command: str, y_data_type: Any = None) -> None:
         """Executes the user program.
 
         Args:

--- a/aiaccel/util/buffer.py
+++ b/aiaccel/util/buffer.py
@@ -165,7 +165,7 @@ class Buffer:
         buff.Add("data3", x)
     """
 
-    def __init__(self, *labels: tuple) -> None:
+    def __init__(self, *labels) -> None:
         self.labels = labels[0]
         self.num_buff = len(self.labels)
         self.d = {}

--- a/aiaccel/util/buffer.py
+++ b/aiaccel/util/buffer.py
@@ -10,10 +10,10 @@ class _buffer:
             labal (str): A name of list.
         """
         self.label = label
-        self.arr: list = []
+        self.arr: list[Any] = []
         self._max_size = 65535
 
-    def __call__(self, index: int):
+    def __call__(self, index: int) -> Any:
         return self.arr[index]
 
     def set_max_len(self, value: int) -> None:
@@ -48,7 +48,7 @@ class _buffer:
         """
         self.arr = []
 
-    def Replace(self, arr: list) -> None:
+    def Replace(self, arr: list[Any]) -> None:
         """ Replace to any list data.
         """
         self.Clear()
@@ -61,7 +61,7 @@ class _buffer:
         return len(self.arr)
 
     @property
-    def Data(self) -> list:
+    def Data(self) -> list[Any]:
         """ Get the list data itself.
         """
         return self.arr
@@ -165,7 +165,7 @@ class Buffer:
         buff.Add("data3", x)
     """
 
-    def __init__(self, *labels) -> None:
+    def __init__(self, *labels: Any) -> None:
         self.labels = labels[0]
         self.num_buff = len(self.labels)
         self.d = {}

--- a/aiaccel/util/easy_visualizer.py
+++ b/aiaccel/util/easy_visualizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+from typing import Any
 
 import numpy as np
 from asciichartpy import (black, blue, cyan, darkgray, green, lightblue,
@@ -20,7 +21,7 @@ class EasyVisualizer:
         cplt.line_plot([values: list])
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.line_colors = {
             "black": black,
             "blue": blue,
@@ -57,15 +58,14 @@ class EasyVisualizer:
             "darkgray",
             "black",
         ]
-        self.plot_config = {
+        self.plot_config: dict[str, Any] = {
             "height": 15,
             "colors": [
                 self.line_colors[self.color_priority[0]],
                 self.line_colors[self.color_priority[1]]
             ]
-
         }
-        self.plot_datas = [[]]
+        self.plot_datas: list[list[Any]] = [[]]
 
     def set_height(self, height: int) -> None:
         """ Set the any height of vertical axis.
@@ -83,7 +83,7 @@ class EasyVisualizer:
     #     """
     #     self.plot_config["width"] = width
 
-    def set_colors(self, colors: list) -> None:
+    def set_colors(self, colors: list[Any]) -> None:
         """ Set the color of line graph.
 
         Args:
@@ -103,7 +103,7 @@ class EasyVisualizer:
             else:
                 raise Exception
 
-    def caption(self, *labels) -> None:
+    def caption(self, *labels: Any) -> None:
         """Set the any caption.
 
         Args:
@@ -114,7 +114,7 @@ class EasyVisualizer:
             color = self.line_colors[self.color_priority[i]]
             print(f'{color}{list(labels)[i]}{reset}')
 
-    def line_plot(self, *data) -> None:
+    def line_plot(self, *data: Any) -> None:
         """ Plot the any data.
 
         Args:
@@ -161,7 +161,7 @@ class EasyVisualizer:
                 self.plot_datas.append(data[i])
         print(plot(series=self.plot_datas, cfg=self.plot_config))
 
-    def sort(self, data: list, goal: str) -> list | None:
+    def sort(self, data: list[Any], goal: str) -> list[Any] | None:
         """ Sort the any data to maximize or minimize.
 
         Args:

--- a/aiaccel/util/easy_visualizer.py
+++ b/aiaccel/util/easy_visualizer.py
@@ -103,7 +103,7 @@ class EasyVisualizer:
             else:
                 raise Exception
 
-    def caption(self, *labels: tuple) -> None:
+    def caption(self, *labels) -> None:
         """Set the any caption.
 
         Args:
@@ -114,7 +114,7 @@ class EasyVisualizer:
             color = self.line_colors[self.color_priority[i]]
             print(f'{color}{list(labels)[i]}{reset}')
 
-    def line_plot(self, *data: tuple) -> None:
+    def line_plot(self, *data) -> None:
         """ Plot the any data.
 
         Args:
@@ -172,7 +172,7 @@ class EasyVisualizer:
             Sorted list, or None.
         """
         if not type(data) == list:
-            return
+            return None
 
         best_values = []
 

--- a/aiaccel/util/filesystem.py
+++ b/aiaccel/util/filesystem.py
@@ -183,7 +183,7 @@ def interprocess_lock_file(path: Path, dict_lock: Path) -> Path:
     return dict_lock / path.parent.name
 
 
-def load_yaml(path: Path, dict_lock: Path | None = None) -> dict:
+def load_yaml(path: Path, dict_lock: Path | None = None) -> dict[str, Any]:
     """Load a content of a yaml file.
 
     Args:

--- a/aiaccel/util/filesystem.py
+++ b/aiaccel/util/filesystem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import fasteners
 import yaml
@@ -8,7 +9,7 @@ import yaml
 import aiaccel
 
 
-def create_yaml(path: Path, content: dict, dict_lock: Path | None = None) -> None:
+def create_yaml(path: Path, content: Any, dict_lock: Path | None = None) -> None:
     """Create a yaml file.
 
     Args:

--- a/aiaccel/util/filesystem.py
+++ b/aiaccel/util/filesystem.py
@@ -150,7 +150,7 @@ def get_file_result(path: Path, dict_lock: Path | None = None
 
 
 def get_file_result_hp(path: Path, dict_lock: Path | None = None
-                       ) -> list[Path] | None:
+                       ) -> Any:
     """Get files in result directory.
 
     Args:

--- a/aiaccel/util/name.py
+++ b/aiaccel/util/name.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import logging
 import string
-
-import numpy as np
+from typing import Any
 
 
 def generate_random_name(
     length: int = 10,
-    rng: np.random.RandomState | None = None
+    rng: Any = None
 ) -> str | None:
     """
     Generate random name using alphanumeric.

--- a/aiaccel/util/process.py
+++ b/aiaccel/util/process.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import threading
 from subprocess import Popen
+from typing import Any
 from typing import TYPE_CHECKING
 
 import psutil
@@ -15,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 import datetime
 
 
-def exec_runner(command: list) -> Popen:
+def exec_runner(command: list[Any]) -> Popen[bytes]:
     """Execute a subprocess with command.
 
     Args:
@@ -31,7 +32,7 @@ def exec_runner(command: list) -> Popen:
     )
 
 
-def subprocess_ps() -> list[dict]:
+def subprocess_ps() -> list[dict[str, Any]]:
     """Get a ps result as a list.
 
     Returns:
@@ -62,7 +63,7 @@ def subprocess_ps() -> list[dict]:
     return ret
 
 
-def ps2joblist() -> list[dict]:
+def ps2joblist() -> list[dict[str, Any]]:
     """Get a ps result and convert to a job list format.
 
     Returns:
@@ -127,7 +128,7 @@ class OutputHandler(threading.Thread):
     def __init__(
         self,
         parent: AbstractScheduler,
-        proc: subprocess.Popen,
+        proc: subprocess.Popen[bytes],
         module_name: str,
         trial_id: int,
         storage: Storage | None = None

--- a/aiaccel/util/process.py
+++ b/aiaccel/util/process.py
@@ -9,9 +9,7 @@ from typing import TYPE_CHECKING
 import psutil
 
 if TYPE_CHECKING:  # pragma: no cover
-    from aiaccel.master.abci_master import AbciMaster
-    from aiaccel.master.abstract_master import AbstractMaster
-    from aiaccel.master.local_master import LocalMaster
+    from aiaccel.scheduler.abstract_scheduler import AbstractScheduler
     from aiaccel.storage.storage import Storage
 
 import datetime
@@ -128,7 +126,7 @@ class OutputHandler(threading.Thread):
 
     def __init__(
         self,
-        parent: AbciMaster | AbstractMaster | LocalMaster,
+        parent: AbstractScheduler,
         proc: subprocess.Popen,
         module_name: str,
         trial_id: int,

--- a/aiaccel/util/process.py
+++ b/aiaccel/util/process.py
@@ -41,8 +41,8 @@ def subprocess_ps() -> list[dict]:
     """
     commands = ['ps', 'xu']
     res = subprocess.run(commands, stdout=subprocess.PIPE)
-    res = res.stdout.decode('utf-8')
-    stats = res.split('\n')
+    message = res.stdout.decode('utf-8')
+    stats = message.split('\n')
     stats_zero = re.split(' +', stats[0])
     stats_zero = [s for s in stats_zero if s != '']
     pid_order = stats_zero.index('PID')

--- a/aiaccel/util/retry.py
+++ b/aiaccel/util/retry.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 import time
+from collections.abc import Callable
 from functools import wraps
+from typing import Any
 
 
-def retry(_MAX_NUM=60, _DELAY=1.0):
+def retry(_MAX_NUM: int = 60, _DELAY: float = 1.0) -> Callable[[Any], Any]:
     """Decorator to retry function.
 
     Args:
         _MAX_NUM (int, optional): Maximum number of retries. Defaults to 60.
         _DELAY (float, optional): Retry interval in seconds. Defaults to 1.0.
     """
-    def _retry(func):
+    def _retry(func: Callable[[Any], Any]) -> Any:
         @wraps(func)
-        def _wrapper(*args, **kwargs):
+        def _wrapper(*args: Any, **kwargs: Any) -> Any:
             for i in range(_MAX_NUM):
                 try:
                     return func(*args, **kwargs)

--- a/aiaccel/util/suffix.py
+++ b/aiaccel/util/suffix.py
@@ -5,7 +5,7 @@ class Suffix:
     """ Create suffix with datetime.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     @classmethod

--- a/aiaccel/util/trialid.py
+++ b/aiaccel/util/trialid.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import fasteners
 
@@ -65,7 +66,7 @@ class TrialId:
             self.count_path.write_text('%d' % trial_id)
             self.lock.release()
 
-    def get(self) -> int | None:
+    def get(self) -> Any:
         """Returns trial id.
 
         Returns:
@@ -87,7 +88,7 @@ class TrialId:
             self.lock.release()
 
     @property
-    def integer(self) -> int | None:
+    def integer(self) -> Any:
         """Trial id.
         """
         return self.get()

--- a/aiaccel/util/trialid.py
+++ b/aiaccel/util/trialid.py
@@ -27,7 +27,7 @@ class TrialId:
         lock (fasteners.InterProcessLock): An interprocess lock.
     """
 
-    def __init__(self, config_path: str) -> None:
+    def __init__(self, config_path: str | Path) -> None:
         self.config_path = Path(config_path).resolve()
         self.config = Config(str(self.config_path))
 

--- a/aiaccel/wrapper_tools.py
+++ b/aiaccel/wrapper_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 from aiaccel import dict_result
 from aiaccel.util.filesystem import create_yaml
@@ -9,7 +10,7 @@ from aiaccel.util.filesystem import create_yaml
 
 def create_runner_command(
     command: str,
-    param_content: dict,
+    param_content: dict[str, Any],
     trial_id: int,
     config_path: str,
     command_error_output: str


### PR DESCRIPTION
Related to #203, This PR removes all of mypy errors using `typing.Any`.
Note, however, this does __not__ make aiaccel __type-safe__.

To check type, following command was used;
```bash
mypy aiaccel --warn-unused-configs --disallow-any-generics --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --disallow-untyped-decorators --warn-redundant-casts --warn-unused-ignores --no-implicit-reexport --strict-equality --strict-concatenate --ignore-missing-imports
```
This command covers almost all options available with the mypy option "`--strict`" except `--disallow-subclassing-any` and `--warn-return-any`.
Additionally, the last option `--ignore-missing-imports` is not included in `--strict` option.

Please check followings carefully since change in the implementations are included.
- aiaccel/config.py - l.256 `ConfigEntry.load_config_values`
- aiaccel/parameter.py - l.110 `HyperParameter.__init__`
- aiaccel/scheduler/abci_scheduler.py - l.54 `AbciScheduler.parse_trial_id`
- aiaccel/scheduler/job/model/abstract_model.py - l.18 `AbstractModel`
- aiaccel/scheduler/job/model/abstract_model.py - l.82 `AbstractModel.change_trial_state`
  - The method `change_trial_state` seems not to be referred.
- aiaccel/scheduler/pylocal_scheduler.py - l.18
- aiaccel/scheduler/pylocal_scheduler.py - l.85 `initializer`
- aiaccel/util/aiaccel.py - l.390 `Run.execute`

---

この PR では `typing.Any` を使用して mypy のエラーを全て解消します．
ただし，型安全なコードが実現したことわけではありません．

型チェックを行うために使用したコマンドは以下の通りです．
```bash
mypy aiaccel --warn-unused-configs --disallow-any-generics --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --check-untyped-defs --disallow-untyped-decorators --warn-redundant-casts --warn-unused-ignores --no-implicit-reexport --strict-equality --strict-concatenate --ignore-missing-imports
```
このコマンドは mypy の実行オプション `--strict` の内， `--disallow-subclassing-any` および `--warn-return-any` 以外の全てを含んでいます．
また，最後のオプション `--ignore-missing-imports` は `--strict` には含まれていません．

以下の項目は，型ヒントだけでなく実装にも変更が加えられたため，レビューを行う際には注意してチェックして頂けると助かります．
- aiaccel/config.py - l.256 `ConfigEntry.load_config_values`
- aiaccel/parameter.py - l.110 `HyperParameter.__init__`
- aiaccel/scheduler/abci_scheduler.py - l.54 `AbciScheduler.parse_trial_id`
- aiaccel/scheduler/job/model/abstract_model.py - l.18 `AbstractModel`
- aiaccel/scheduler/job/model/abstract_model.py - l.82 `AbstractModel.change_trial_state`
  - The method `change_trial_state` seems not to be referred.
- aiaccel/scheduler/pylocal_scheduler.py - l.18
- aiaccel/scheduler/pylocal_scheduler.py - l.85 `initializer`
- aiaccel/util/aiaccel.py - l.390 `Run.execute`
