### PR TITLE
change deprecated github-actions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -12,10 +12,10 @@ jobs:
         python-version: ['3.8']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set Up ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
This PR changes deprecated github-actions: `actions/checkout@v2` and `actions/setup-python@v2` are changed to `actions/checkout@v3` and `actions/setup-python@v4`, respectively.

Close #244 