### PR TITLE
remove `typing.Any` from module creation functions.

### DIFF
--- a/aiaccel/cli/start.py
+++ b/aiaccel/cli/start.py
@@ -11,6 +11,7 @@ from aiaccel.cli import CsvWriter
 from aiaccel.common import dict_lock, goal_maximize, goal_minimize
 from aiaccel.config import Config, is_multi_objective
 from aiaccel.master import create_master
+from aiaccel.module import AbstractModule
 from aiaccel.optimizer import create_optimizer
 from aiaccel.scheduler import create_scheduler
 from aiaccel.util import get_file_result_hp, load_yaml
@@ -108,7 +109,7 @@ def main() -> None:  # pragma: no cover
     Master = create_master(args.config)
     Optimizer = create_optimizer(args.config)
     Scheduler = create_scheduler(args.config)
-    modules = [Master(vars(args)), Optimizer(vars(args)), Scheduler(vars(args))]
+    modules: list[AbstractModule] = [Master(vars(args)), Optimizer(vars(args)), Scheduler(vars(args))]
 
     sleep_time = config.sleep_time.get()
     time_s = time.time()

--- a/aiaccel/master/create.py
+++ b/aiaccel/master/create.py
@@ -1,35 +1,41 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Type
+from typing import Union
 
 from aiaccel.config import Config
 from aiaccel.master import AbciMaster
 from aiaccel.master import LocalMaster
 from aiaccel.master import PylocalMaster
 
+# TODO: Replace typing.Type with builtins.type when aiaccel supports python>=3.9.
+MasterType = Type[Union[AbciMaster, LocalMaster, PylocalMaster]]
 
-def create_master(config_path: str) -> Any:
+
+def create_master(config_path: str) -> MasterType:
     """Returns master type.
 
     Args:
         config_path (str): Path to configuration file.
 
+    Raises:
+        ValueError: Causes when specified resource type is invalid.
+
     Returns:
-        type | None: `LocalMaster`, `PylocalMaster`, or `AbciMaster`
+        MasterType: `LocalMaster`, `PylocalMaster`, or `AbciMaster`
             if resource type is 'local', 'python_local', or 'abci',
-            respectively. Other cases, None.
+            respectively.
     """
     config = Config(config_path)
     resource = config.resource_type.get()
-
     if resource.lower() == "local":
         return LocalMaster
-
     elif resource.lower() == "python_local":
         return PylocalMaster
-
     elif resource.lower() == "abci":
         return AbciMaster
-
     else:
-        return None
+        raise ValueError(
+            f"Invalid resource type \"{resource}\". "
+            "The resource type should be one of \"local\", \"python_local\", and \"abci\"."
+        )

--- a/aiaccel/optimizer/create.py
+++ b/aiaccel/optimizer/create.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Type
 
 from importlib import import_module
 
 from aiaccel.config import Config
+from aiaccel.optimizer import AbstractOptimizer
+
+# TODO: Replace typing.Type with builtins.type when aiaccel supports python>=3.9.
+OptimizerType = Type[AbstractOptimizer]
 
 
-def create_optimizer(config_path: str) -> Any:
+def create_optimizer(config_path: str) -> OptimizerType:
     """Returns master type.
 
     Args:
@@ -20,7 +24,7 @@ def create_optimizer(config_path: str) -> Any:
     return import_and_getattr(config.search_algorithm.get())
 
 
-def import_and_getattr(name: str) -> Any:
+def import_and_getattr(name: str) -> OptimizerType:
     """Imports the specified Optimizer class.
 
     Args:

--- a/aiaccel/scheduler/create.py
+++ b/aiaccel/scheduler/create.py
@@ -1,35 +1,40 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Type
+from typing import Union
 
 from aiaccel.config import Config
 from aiaccel.scheduler import AbciScheduler
 from aiaccel.scheduler import LocalScheduler
 from aiaccel.scheduler import PylocalScheduler
 
+# TODO: Replace typing.Type with builtins.type when aiaccel supports python>=3.9.
+SchedulerType = Type[Union[AbciScheduler, LocalScheduler, PylocalScheduler]]
 
-def create_scheduler(config_path: str) -> Any:
+
+def create_scheduler(config_path: str) -> SchedulerType:
     """Returns scheduler type.
 
     Args:
         config_path (str): Path to configuration file.
 
+    Raises:
+        ValueError: Causes when specified resource type is invalid.
+
     Returns:
         type | None: `LocalScheduler` , `PylocalScheduler` , or `AbciScheduler`
         if resource type is 'local', 'python_local', or 'abci', respectively.
-        Other cases, None.
     """
     config = Config(config_path)
     resource = config.resource_type.get()
-
     if resource.lower() == "local":
         return LocalScheduler
-
     elif resource.lower() == "python_local":
         return PylocalScheduler
-
     elif resource.lower() == "abci":
         return AbciScheduler
-
     else:
-        return None
+        raise ValueError(
+            f"Invalid resource type \"{resource}\". "
+            "The resource type should be one of \"local\", \"python_local\", and \"abci\"."
+        )

--- a/tests/unit/master_test/test_create.py
+++ b/tests/unit/master_test/test_create.py
@@ -1,6 +1,8 @@
+import pytest
 
 from aiaccel.master import AbciMaster
 from aiaccel.master import LocalMaster
+from aiaccel.master import PylocalMaster
 from aiaccel.master import create_master
 
 
@@ -11,5 +13,9 @@ def test_create():
     config_local = "tests/test_data/config.json"
     assert create_master(config_local) == LocalMaster
 
-    config_local = "tests/test_data/config_invalid_resource.json"
-    assert create_master(config_local) is None
+    config_python_local = "tests/test_data/config_python_local.json"
+    assert create_master(config_python_local) == PylocalMaster
+
+    with pytest.raises(ValueError):
+        config_invalid = "tests/test_data/config_invalid_resource.json"
+        _ = create_master(config_invalid)

--- a/tests/unit/scheduler_test/test_create.py
+++ b/tests/unit/scheduler_test/test_create.py
@@ -1,3 +1,5 @@
+import pytest
+
 from aiaccel.scheduler import AbciScheduler
 from aiaccel.scheduler import LocalScheduler
 from aiaccel.scheduler import PylocalScheduler
@@ -14,5 +16,6 @@ def test_create():
     config_python_local = "tests/test_data/config_python_local.json"
     assert create_scheduler(config_python_local) == PylocalScheduler
 
-    config_invalid = "tests/test_data/config_invalid_resource.json"
-    assert create_scheduler(config_invalid) is None
+    with pytest.raises(ValueError):
+        config_invalid = "tests/test_data/config_invalid_resource.json"
+        _ = create_scheduler(config_invalid)


### PR DESCRIPTION
This PR removes typing.Any from optimizer/create.py scheduler/create.py, and master/create.py by only changing type annotations.

Note that no implementation is changed.