### PR TITLE
implement command line option container

### DIFF
--- a/aiaccel/__init__.py
+++ b/aiaccel/__init__.py
@@ -1,5 +1,6 @@
 from aiaccel import common
 from aiaccel import config
+from aiaccel import command_line_options
 from aiaccel import module
 from aiaccel import parameter
 from aiaccel import workspace
@@ -16,6 +17,7 @@ from aiaccel import util
 __all__ = [
     'common',
     'config',
+    'command_line_options',
     'module',
     'parameter',
     'workspace',

--- a/aiaccel/command_line_options.py
+++ b/aiaccel/command_line_options.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CommandLineOptions:
+    config: str
+    resume: int | None
+    clean: bool
+    process_name: str = field(default="")

--- a/aiaccel/master/abci_master.py
+++ b/aiaccel/master/abci_master.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import dict_runner
 from aiaccel.abci import parse_qstat
 from aiaccel.master import AbstractMaster
@@ -13,15 +14,15 @@ class AbciMaster(AbstractMaster):
     """A master class running on ABCI environment.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
-            command line options.
+        options (CommandLineOptions): A dataclass object containing
+            command line options as well as process name.
 
     Attributes:
         runner_files (list[Path]): A list of path of runner files.
         stats (list[dict]): A result string of 'qstat' command.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         super().__init__(options)
         self.runner_files = []
         self.stats = []

--- a/aiaccel/master/abstract_master.py
+++ b/aiaccel/master/abstract_master.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import goal_maximize, goal_minimize
 from aiaccel.config import is_multi_objective
 from aiaccel.master import AbstractVerification, MaximizeEvaluator, MinimizeEvaluator
@@ -20,11 +21,11 @@ class AbstractMaster(AbstractModule):
     """An abstract class for AbciMaster and LocalMaster.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
-            command line options.
+        options (CommandLineOptions): A dataclass object containing
+            command line options as well as process name.
 
     Attributes:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options as well as process name.
         loop_start_time (datetime.datetime): A stored loop starting time.
         optimizer_proc (subprocess.Popen): A reference for a subprocess of
@@ -38,11 +39,11 @@ class AbstractMaster(AbstractModule):
         stats (list):
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         self.start_time = get_time_now_object()
         self.loop_start_time: datetime | None = None
         self.options = options
-        self.options["process_name"] = "master"
+        self.options.process_name = "master"
 
         super().__init__(self.options)
         self.logger = logging.getLogger("root.master")

--- a/aiaccel/master/evaluator/abstract_evaluator.py
+++ b/aiaccel/master/evaluator/abstract_evaluator.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import dict_lock
 from aiaccel.common import dict_result
 from aiaccel.common import file_final_result
@@ -17,12 +18,10 @@ class AbstractEvaluator(object):
     """An abstract class for MaximizeEvaluator and MinimizeEvaluator.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options as well as process name.
 
     Attributes:
-        options (dict[str, str | int | bool]): A dictionary containing
-            command line options as well as process name.
         config_path (Path): Path to the configuration file.
         config (Config): Config object.
         ws (Path): Path to the workspace.
@@ -34,9 +33,8 @@ class AbstractEvaluator(object):
 
     """
 
-    def __init__(self, options: dict[str, Any]) -> None:
-        self.options = options
-        self.config_path = Path(self.options['config']).resolve()
+    def __init__(self, options: CommandLineOptions) -> None:
+        self.config_path = Path(options.config).resolve()
         self.config = Config(str(self.config_path))
         self.ws = Path(self.config.workspace.get()).resolve()
         self.dict_lock = self.ws / dict_lock

--- a/aiaccel/master/verification/abstract_verification.py
+++ b/aiaccel/master/verification/abstract_verification.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import dict_lock
 from aiaccel.common import dict_verification
 from aiaccel.common import extension_verification
@@ -17,7 +18,7 @@ class AbstractVerification(object):
     """An abstract class of verification.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options as well as process name.
 
     Attributes:
@@ -38,10 +39,10 @@ class AbstractVerification(object):
         storage (Storage): Storage object.
     """
 
-    def __init__(self, options: dict[str, Any]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         # === Load config file===
         self.options = options
-        self.config = Config(self.options['config'])
+        self.config = Config(self.options.config)
         self.ws = Path(self.config.workspace.get()).resolve()
         self.dict_lock = self.ws / dict_lock
         self.is_verified: bool = False

--- a/aiaccel/optimizer/abstract_optimizer.py
+++ b/aiaccel/optimizer/abstract_optimizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.module import AbstractModule
 from aiaccel.parameter import load_parameter
 from aiaccel.util import str_to_logging_level
@@ -14,12 +15,12 @@ class AbstractOptimizer(AbstractModule):
     """An abstract class for Optimizer classes.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options.
 
     Attributes:
-        options (dict[str, str | int | bool]): A dictionary containing
-            command line options.
+        options (CommandLineOptions): A dataclass object containing
+            command line options as well as process name.
         hp_ready (int): A ready number of hyper parameters.
         hp_running (int): A running number of hyper prameters.
         hp_finished (int): A finished number of hyper parameters.
@@ -32,9 +33,9 @@ class AbstractOptimizer(AbstractModule):
         trial_id (TrialId): TrialId object.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         self.options = options
-        self.options['process_name'] = 'optimizer'
+        self.options.process_name = 'optimizer'
         super().__init__(self.options)
 
         self.set_logger(
@@ -226,14 +227,11 @@ class AbstractOptimizer(AbstractModule):
         Returns:
             None
         """
-        if (
-            self.options['resume'] is not None and
-            self.options['resume'] > 0
-        ):
-            self.storage.rollback_to_ready(self.options['resume'])
-            self.storage.delete_trial_data_after_this(self.options['resume'])
-            self.trial_id.initial(num=self.options['resume'])
-            self._deserialize(self.options['resume'])
+        if isinstance(self.options.resume, int) and self.options.resume > 0:
+            self.storage.rollback_to_ready(self.options.resume)
+            self.storage.delete_trial_data_after_this(self.options.resume)
+            self.trial_id.initial(num=self.options.resume)
+            self._deserialize(self.options.resume)
 
     def cast(self, params: list[dict[str, Any]]) -> list[Any] | None:
         """Casts types of parameter values to appropriate tepes.

--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -4,6 +4,7 @@ from functools import reduce
 from operator import mul
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.config import Config
 from aiaccel.optimizer import AbstractOptimizer
 from aiaccel.parameter import HyperParameter
@@ -115,7 +116,7 @@ class GridOptimizer(AbstractOptimizer):
     """An optimizer class with grid search algorithm.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options.
 
     Attributes:
@@ -123,7 +124,7 @@ class GridOptimizer(AbstractOptimizer):
         generate_index (int): A number of generated hyper parameters.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         super().__init__(options)
         self.ready_params: Any = None
         self.generate_index: Any = None

--- a/aiaccel/optimizer/motpe_optimizer.py
+++ b/aiaccel/optimizer/motpe_optimizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import optuna
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.optimizer.tpe_optimizer import TpeOptimizer, TPESamplerWrapper
 
 
@@ -9,10 +10,11 @@ class MOTpeOptimizer(TpeOptimizer):
     """An optimizer class based on multi-objective optuna.samplers.TPESampler.
 
     Args:
-        options (dict): A dictionary containing command line options.
+        options (CommandLineOptions): A dataclass object containing
+            command line options.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         """Initial method of MOTpeOptimizer.
 
         Args:
@@ -33,7 +35,7 @@ class MOTpeOptimizer(TpeOptimizer):
         sampler._random_sampler._rng = self._rng
         storage_path = str(f"sqlite:///{self.ws}/optuna-{self.study_name}.db")
         storage = optuna.storages.RDBStorage(url=storage_path)
-        load_if_exists = self.options["resume"] is not None
+        load_if_exists = self.options.resume is not None
 
         self.study = optuna.create_study(
             sampler=sampler,

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.optimizer import NelderMead
 from aiaccel.optimizer import AbstractOptimizer
 from aiaccel.parameter import HyperParameter, HyperParameterConfiguration
@@ -11,8 +12,8 @@ class NelderMeadOptimizer(AbstractOptimizer):
     """An optimizer class with nelder mead algorithm.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
-        command line options.
+        options (CommandLineOptions): A dataclass object containing
+            command line options.
 
     Attributes:
         nelder_mead (NelderMead): A class object implementing Nelder-Mead
@@ -21,7 +22,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
         order (list): A list of parameters being processed.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         super().__init__(options)
         self.nelder_mead: Any = None
         self.parameter_pool: list[dict[str, Any]] = []

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from scipy.stats import qmc
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.optimizer import AbstractOptimizer
 
 
@@ -11,7 +12,7 @@ class SobolOptimizer(AbstractOptimizer):
     """An optimizer class with sobol algorithm.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options.
 
     Attributes:
@@ -24,7 +25,7 @@ class SobolOptimizer(AbstractOptimizer):
         Confirm whether the current code resumes for any timings of quits.
     """
 
-    def __init__(self, options: dict[str, str | int | bool]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         super().__init__(options)
         self.generate_index: Any = None
         self.sampler: Any = None
@@ -40,7 +41,7 @@ class SobolOptimizer(AbstractOptimizer):
         finished = self.storage.trial.get_finished()
         self.generate_index = len(finished)
 
-        if self.options['resume'] is None or self.options['resume'] <= 0:
+        if self.options.resume is None or self.options.resume <= 0:
             self.sampler = qmc.Sobol(
                 d=len(self.params.get_parameter_list()),
                 scramble=self.config.sobol_scramble.get(),

--- a/aiaccel/scheduler/abstract_scheduler.py
+++ b/aiaccel/scheduler/abstract_scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import dict_result
 from aiaccel.module import AbstractModule
 from aiaccel.scheduler import RandomSampling
@@ -16,11 +17,11 @@ class AbstractScheduler(AbstractModule):
     """An abstract class for AbciScheduler and LocalScheduler.
 
     Args:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options.
 
     Attributes:
-        options (dict[str, str | int | bool]): A dictionary containing
+        options (CommandLineOptions): A dataclass object containing
             command line options.
         config_path (Path): Path to the configuration file.
         algorithm (RandomSampling): A scheduling algorithm
@@ -32,12 +33,12 @@ class AbstractScheduler(AbstractModule):
             command or qstat command.
     """
 
-    def __init__(self, options: dict[str, Any]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         self.options = options
-        self.options['process_name'] = 'scheduler'
+        self.options.process_name = "scheduler"
         super().__init__(self.options)
 
-        self.config_path = Path(self.options['config']).resolve()
+        self.config_path = Path(self.options.config).resolve()
 
         self.set_logger(
             'root.scheduler',
@@ -277,11 +278,8 @@ class AbstractScheduler(AbstractModule):
         Returns:
             None
         """
-        if (
-            self.options['resume'] is not None and
-            self.options['resume'] > 0
-        ):
-            self._deserialize(self.options['resume'])
+        if isinstance(self.options.resume, int) and self.options.resume > 0:
+            self._deserialize(self.options.resume)
 
     def create_result_file(self, trial_id: int) -> None:
         """ Save the results in yaml format.

--- a/aiaccel/scheduler/pylocal_scheduler.py
+++ b/aiaccel/scheduler/pylocal_scheduler.py
@@ -6,6 +6,7 @@ from importlib.util import module_from_spec
 from pathlib import Path
 from typing import Any
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.scheduler import AbstractScheduler
 from aiaccel.util.aiaccel import Run
 from aiaccel.util.aiaccel import WrapperInterface
@@ -27,7 +28,7 @@ class PylocalScheduler(AbstractScheduler):
 
     """
 
-    def __init__(self, options: dict[str, Any]) -> None:
+    def __init__(self, options: CommandLineOptions) -> None:
         super().__init__(options)
         self.run = Run(self.config_path)
         self.com = WrapperInterface()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -6,7 +6,7 @@ import shutil
 from aiaccel.config import Config
 from aiaccel.util import create_yaml
 from aiaccel.workspace import Workspace
-import shutil
+
 
 d0 = {
     "end_time": "11/03/2020 16:07:45",

--- a/tests/unit/master_test/evaluator_test/test_abstract_evaluator.py
+++ b/tests/unit/master_test/evaluator_test/test_abstract_evaluator.py
@@ -1,3 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import dict_hp_finished
 from aiaccel.common import dict_result
 from aiaccel.common import extension_hp
@@ -7,62 +16,44 @@ from tests.base_test import BaseTest
 
 
 class TestAbstractEvaluator(BaseTest):
+    @pytest.fixture(autouse=True)
+    def setup_options(self) -> Generator[None, None, None]:
+        self.options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="test"
+        )
+        self.evaluator = AbstractEvaluator(self.options)
+        yield
+        self.options = None
+        self.evaluator = None
 
-    def test_init(self):
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'test'
-        }
-        evaluator = AbstractEvaluator(options)
-        assert evaluator.hp_result is None
+    def test_init(self) -> None:
+        assert self.evaluator.hp_result is None
 
-    def test_evaluate(self):
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'test'
-        }
-        evaluator = AbstractEvaluator(options)
-        assert evaluator.evaluate() is None
+    def test_evaluate(self) -> None:
+        assert self.evaluator.evaluate() is None
 
-        # try:
-        #     evaluator.evaluate()
-        #     assert False
-        # except NotImplementedError:
-        #     assert True
-
-    def test_print(self, setup_hp_finished, work_dir):
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'test'
-        }
-
-        evaluator = AbstractEvaluator(options)
+    def test_print(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        setup_hp_finished: Callable[[int], None],
+        work_dir: Path
+    ) -> None:
         setup_hp_finished(1)
-        evaluator.hp_result = work_dir.joinpath(
-            dict_hp_finished, f'001.{extension_hp}')
-        assert evaluator.print() is None
+        with monkeypatch.context() as m:
+            m.setattr(self.evaluator, "hp_result", work_dir.joinpath(dict_hp_finished, f'001.{extension_hp}'))
+            assert self.evaluator.print() is None
 
-    def test_save(self, setup_hp_finished, work_dir):
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'test'
-        }
-
-        evaluator = AbstractEvaluator(options)
+    def test_save(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        setup_hp_finished: Callable[[int], None],
+        work_dir: Path
+    ) -> None:
         setup_hp_finished(1)
-        evaluator.hp_result = work_dir.joinpath(
-            dict_hp_finished, f'001.{extension_hp}')
-        evaluator.save()
-        assert work_dir.joinpath(dict_result, file_final_result).exists()
+        with monkeypatch.context() as m:
+            m.setattr(self.evaluator, "hp_result", work_dir.joinpath(dict_hp_finished, f'001.{extension_hp}'))
+            self.evaluator.save()
+            assert work_dir.joinpath(dict_result, file_final_result).exists()

--- a/tests/unit/master_test/evaluator_test/test_maximize_evaluator.py
+++ b/tests/unit/master_test/evaluator_test/test_maximize_evaluator.py
@@ -1,3 +1,4 @@
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.master import MaximizeEvaluator
 
 from tests.base_test import BaseTest
@@ -5,12 +6,11 @@ from tests.base_test import BaseTest
 
 class TestMaximizeEvaluator(BaseTest):
     def test_maximize_evaluator(self):
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+        )
         evaluator = MaximizeEvaluator(options)
         evaluator.evaluate()
         assert evaluator.hp_result is None

--- a/tests/unit/master_test/evaluator_test/test_minimize_evaluator.py
+++ b/tests/unit/master_test/evaluator_test/test_minimize_evaluator.py
@@ -1,3 +1,4 @@
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.master import MinimizeEvaluator
 
 from tests.base_test import BaseTest
@@ -5,13 +6,12 @@ from tests.base_test import BaseTest
 
 class TestMinimizeEvaluator(BaseTest):
     def test_maximize_evaluator(self):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         evaluator = MinimizeEvaluator(options)
         evaluator.evaluate()
         assert evaluator.hp_result is None

--- a/tests/unit/master_test/test_abci_master.py
+++ b/tests/unit/master_test/test_abci_master.py
@@ -5,6 +5,7 @@ import time
 from unittest.mock import patch
 
 import pytest
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.master import AbciMaster
 from tests.arguments import parse_arguments
 from tests.base_test import BaseTest
@@ -45,7 +46,12 @@ class TestAbciMaster(BaseTest):
         with patch.object(sys, 'argv', commandline_args):
             # from aiaccel import start
             # self.master = start.Master()
-            options = parse_arguments()
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
             # self.master = create_master(options['config'])(options)
             self.master = AbciMaster(options)
 
@@ -64,7 +70,12 @@ class TestAbciMaster(BaseTest):
             str(self.config_path)
         ]
         with patch.object(sys, 'argv', commandline_args):
-            options = parse_arguments()
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
             master = AbciMaster(options)
         master.pre_process()
         assert type(master.runner_files) is list
@@ -83,7 +94,12 @@ class TestAbciMaster(BaseTest):
             str(self.config_path)
         ]
         with patch.object(sys, 'argv', commandline_args):
-            options = parse_arguments()
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
             master = AbciMaster(options)
 
         xml_path = data_dir.joinpath('qstat.xml')

--- a/tests/unit/master_test/test_abstract_master.py
+++ b/tests/unit/master_test/test_abstract_master.py
@@ -5,6 +5,7 @@ import sys
 import time
 from unittest.mock import patch
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import goal_maximize
 from aiaccel.config import Config
 from aiaccel.master import AbstractMaster
@@ -44,7 +45,12 @@ class TestAbstractMaster(BaseTest):
         ]
 
         with patch.object(sys, 'argv', commandline_args):
-            options = parse_arguments()
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
             master = AbstractMaster(options)
         loop = asyncio.get_event_loop()
         gather = asyncio.gather(
@@ -63,7 +69,12 @@ class TestAbstractMaster(BaseTest):
             format(self.config_json)
         ]
         with patch.object(sys, 'argv', commandline_args):
-            options = parse_arguments()
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
             master = AbstractMaster(options)
 
         try:
@@ -78,13 +89,12 @@ class TestAbstractMaster(BaseTest):
         database_remove
     ):
         database_remove()
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         master = AbstractMaster(options)
         setup_hp_finished(10)
         assert master.pre_process() is None
@@ -94,13 +104,12 @@ class TestAbstractMaster(BaseTest):
         database_remove
     ):
         database_remove()
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         master = AbstractMaster(options)
 
         for i in range(10):
@@ -145,7 +154,12 @@ class TestAbstractMaster(BaseTest):
         with patch.object(sys, 'argv', commandline_args):
             # from aiaccel import start
             # master = start.Master()
-            options = parse_arguments()
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
             master = AbstractMaster(options)
 
         # master = AbstractMaster(config_json)
@@ -168,15 +182,19 @@ class TestAbstractMaster(BaseTest):
             "--config",
             format(self.config_json)
         ]
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         with patch.object(sys, 'argv', commandline_args):
-            options = parse_arguments()
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
             master = AbstractMaster(options)
 
         master.pre_process()

--- a/tests/unit/master_test/test_local_master.py
+++ b/tests/unit/master_test/test_local_master.py
@@ -1,3 +1,4 @@
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.master import LocalMaster
 
 from tests.base_test import BaseTest
@@ -6,12 +7,11 @@ from tests.base_test import BaseTest
 class TestLocalMaster(BaseTest):
 
     def test_init(self, clean_work_dir):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         master = LocalMaster(options)
         assert master.loop_start_time is None

--- a/tests/unit/master_test/verification_test/test_abstract_verification.py
+++ b/tests/unit/master_test/verification_test/test_abstract_verification.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import dict_verification
 from aiaccel.common import extension_verification
 from aiaccel.master import AbstractVerification
@@ -10,26 +11,22 @@ from tests.base_test import BaseTest
 class TestAbstractVerification(BaseTest):
 
     def test_init(self):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
-
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         verification = AbstractVerification(options)
         assert verification.is_verified
 
     def test_verify(self, setup_hp_finished, work_dir):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
-
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         verification = AbstractVerification(options)
         verification.is_verified = False
         assert verification.verify() is None
@@ -65,14 +62,12 @@ class TestAbstractVerification(BaseTest):
         setup_hp_finished,
         work_dir
     ):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
-
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         verification = AbstractVerification(options)
         setup_hp_finished(10)
 
@@ -112,13 +107,12 @@ class TestAbstractVerification(BaseTest):
                 assert verification.make_verification(0, 0) is None
 
     def test_print(self):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         verification = AbstractVerification(options)
         verification.is_verified = False
         assert verification.print() is None
@@ -126,13 +120,12 @@ class TestAbstractVerification(BaseTest):
         assert verification.print() is None
 
     def test_save(self, work_dir):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         verification = AbstractVerification(options)
         verification.is_verified = False
         assert verification.save(1) is None

--- a/tests/unit/optimizer_test/test_abstract_optimizer.py
+++ b/tests/unit/optimizer_test/test_abstract_optimizer.py
@@ -5,6 +5,8 @@ import time
 from unittest.mock import patch
 
 import pytest
+
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.optimizer import AbstractOptimizer
 from tests.base_test import BaseTest
 
@@ -24,13 +26,12 @@ class TestAbstractOptimizer(BaseTest):
 
     @pytest.fixture(autouse=True)
     def setup_optimizer(self, clean_work_dir):
-        options = {
-            'config': self.config_json,
-            'resume': 0,
-            'clean': False,
-            'fs': False,
-            'process_name': 'optimizer'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=0,
+            clean=False,
+            process_name="optimizer"
+        )
         self.optimizer = AbstractOptimizer(options)
         yield
         self.optimizer = None

--- a/tests/unit/optimizer_test/test_motpe_search.py
+++ b/tests/unit/optimizer_test/test_motpe_search.py
@@ -1,8 +1,10 @@
 import warnings
+import copy
 
 import numpy as np
 import pytest
-from aiaccel.optimizer.motpe_optimizer import MOTpeOptimizer
+from aiaccel.command_line_options import CommandLineOptions
+from aiaccel.optimizer import MOTpeOptimizer
 
 from tests.base_test import BaseTest
 from unittest.mock import patch
@@ -14,13 +16,12 @@ class TestMOTpeOptimizer(BaseTest):
     def setup_optimizer(self, data_dir, create_tmp_config):
         self.data_dir = data_dir
         self.config_motpe_path = create_tmp_config(self.data_dir / 'config_motpe.json')
-        self.options = {
-            'config': self.config_motpe_path,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'optimizer',
-        }
+        self.options = CommandLineOptions(
+            config=str(self.config_motpe_path),
+            resume=None,
+            clean=False,
+            process_name="optimizer"
+        )
         self.optimizer = MOTpeOptimizer(self.options)
         # self.optimizer.config.goal.set(['minimize'])
         yield
@@ -64,7 +65,7 @@ class TestMOTpeOptimizer(BaseTest):
                 assert self.optimizer.generate_parameter() is None
 
     def test_generate_initial_parameter(self, create_tmp_config):
-        options = self.options.copy()
+        options = copy.copy(self.options)
         self.config_motpe_path = create_tmp_config(self.data_dir / 'config_motpe_no_initial_params.json')
         optimizer = MOTpeOptimizer(self.options)
         (optimizer.ws / 'storage' / 'storage.db').unlink()

--- a/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
+++ b/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
@@ -2,6 +2,7 @@ import json
 import numpy as np
 import pytest
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import goal_maximize
 from aiaccel.config import ConfileWrapper
 from aiaccel.optimizer import NelderMead
@@ -16,13 +17,12 @@ class TestNelderMeadOptimizer(BaseTest):
 
     @pytest.fixture(autouse=True)
     def setup_optimizer(self, clean_work_dir):
-        self.options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'optimizer'
-        }
+        self.options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="optimizer"
+        )
         self.optimizer = NelderMeadOptimizer(self.options)
         yield
         self.optimizer = None

--- a/tests/unit/optimizer_test/test_random_optimizer.py
+++ b/tests/unit/optimizer_test/test_random_optimizer.py
@@ -1,4 +1,5 @@
-from aiaccel.optimizer.random_optimizer import RandomOptimizer
+from aiaccel.command_line_options import CommandLineOptions
+from aiaccel.optimizer import RandomOptimizer
 
 from tests.base_test import BaseTest
 
@@ -7,13 +8,12 @@ class TestRandomOptimizer(BaseTest):
 
     def test_generate_parameter(self, create_tmp_config):
         self.config_random_path = create_tmp_config(self.config_random_path)
-        options = {
-            'config': str(self.config_random_path),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'optimizer'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_random_path),
+            resume=None,
+            clean=False,
+            process_name="optimizer"
+        )
         optimizer = RandomOptimizer(options)
         optimizer.pre_process()
         assert len(optimizer.generate_parameter()) > 0

--- a/tests/unit/optimizer_test/test_sobol_optimizer.py
+++ b/tests/unit/optimizer_test/test_sobol_optimizer.py
@@ -1,8 +1,12 @@
+import copy
+
 import pytest
-from aiaccel.optimizer.sobol_optimizer import SobolOptimizer
+from unittest.mock import patch
+
+from aiaccel.command_line_options import CommandLineOptions
+from aiaccel.optimizer import SobolOptimizer
 
 from tests.base_test import BaseTest
-from unittest.mock import patch
 
 
 class TestSobolOptimizer(BaseTest):
@@ -11,29 +15,28 @@ class TestSobolOptimizer(BaseTest):
     def setup_optimizer(self, data_dir, create_tmp_config):
         self.data_dir = data_dir
         self.config_sobol_path = create_tmp_config(self.config_sobol_path)
-        self.options = {
-            'config': self.config_sobol_path,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'optimizer'
-        }
+        self.options = CommandLineOptions(
+            config=str(self.config_sobol_path),
+            resume=None,
+            clean=False,
+            process_name="optimizer"
+        )
         self.optimizer = SobolOptimizer(self.options)
         yield
         self.optimizer = None
 
     def test_pre_process(self):
-        options = self.options.copy()
+        options = copy.copy(self.options)
         optimizer = SobolOptimizer(options)
         assert optimizer.pre_process() is None
 
-        options = self.options.copy()
+        options = copy.copy(self.options)
         optimizer = SobolOptimizer(options)
         with patch.object(optimizer.storage.trial, 'get_finished', return_value=[0, 1, 2]):
             assert optimizer.pre_process() is None
 
     def test_generate_parameter(self):
-        options = self.options.copy()
+        options = copy.copy(self.options)
         optimizer = SobolOptimizer(options)
         optimizer.pre_process()
 
@@ -43,7 +46,7 @@ class TestSobolOptimizer(BaseTest):
             assert len(optimizer.generate_parameter()) > 0
 
     def test_generate_initial_parameter(self, create_tmp_config):
-        options = self.options.copy()
+        options = copy.copy(self.options)
         optimizer = SobolOptimizer(options)
         optimizer.pre_process()
         optimizer.generate_initial_parameter()

--- a/tests/unit/optimizer_test/test_tpe_optimizer.py
+++ b/tests/unit/optimizer_test/test_tpe_optimizer.py
@@ -1,8 +1,10 @@
+import copy
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.config import Config
 from aiaccel.optimizer import TpeOptimizer
 from aiaccel.optimizer.tpe_optimizer import TPESamplerWrapper, create_distributions
@@ -21,13 +23,12 @@ class TestTpeOptimizer(BaseTest):
     def setup_optimizer(self, data_dir, create_tmp_config):
         self.data_dir = data_dir
         self.config_tpe_path = create_tmp_config(self.data_dir / "config_tpe.json")
-        self.options = {
-            "config": self.config_tpe_path,
-            "resume": None,
-            "clean": False,
-            "fs": False,
-            "process_name": "optimizer",
-        }
+        self.options = CommandLineOptions(
+            config=str(self.config_tpe_path),
+            resume=None,
+            clean=False,
+            process_name="optimizer"
+        )
         self.optimizer = TpeOptimizer(self.options)
         yield
         self.optimizer = None
@@ -67,7 +68,7 @@ class TestTpeOptimizer(BaseTest):
                 assert self.optimizer.generate_parameter() is None
 
     def test_generate_initial_parameter(self, create_tmp_config):
-        options = self.options.copy()
+        options = copy.copy(self.options)
         self.config_tpe_path = create_tmp_config(self.data_dir / "config_tpe_2.json")
         optimizer = TpeOptimizer(self.options)
         (optimizer.ws / "storage" / "storage.db").unlink()

--- a/tests/unit/scheduler_test/job_test/test_job_thread.py
+++ b/tests/unit/scheduler_test/job_test/test_job_thread.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import dict_hp_finished
 from aiaccel.common import dict_hp_ready
 from aiaccel.common import dict_hp_running
@@ -59,8 +60,13 @@ class TestModel(BaseTest):
         with patch.object(sys, 'argv', commandline_args):
             # from aiaccel import start
             # scheduler = start.Scheduler()
-            options = parse_arguments()
-            scheduler = create_scheduler(options['config'])(options)
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
+            scheduler = create_scheduler(options.config)(options)
         # scheduler = LocalScheduler(config_json)
         # config = load_test_config()
         setup_hp_ready(1)
@@ -98,8 +104,13 @@ class TestModel(BaseTest):
         with patch.object(sys, 'argv', commandline_args):
             # from aiaccel import start
             # scheduler = start.Scheduler()
-            options = parse_arguments()
-            scheduler = create_scheduler(options['config'])(options)
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
+            scheduler = create_scheduler(options.config)(options)
         # scheduler = LocalScheduler(config_json)
         trial_id = 1
         self.abci_job = Job(
@@ -404,8 +415,13 @@ class TestJob(BaseTest):
         with patch.object(sys, 'argv', commandline_args):
             # from aiaccel import start
             # scheduler = start.Scheduler()
-            options = parse_arguments()
-            scheduler = create_scheduler(options['config'])(options)
+            dict_options = parse_arguments()
+            options = CommandLineOptions(
+                config=dict_options["config"],
+                resume=dict_options["resume"],
+                clean=dict_options["clean"],
+            )
+            scheduler = create_scheduler(options.config)(options)
         # scheduler = LocalScheduler(config_json)
         # config = load_test_config()
         setup_hp_ready(1)
@@ -428,14 +444,12 @@ class TestJob(BaseTest):
         work_dir,
         database_remove
     ):
-
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'scheduler'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="scheduler"
+        )
         scheduler = LocalScheduler(options)
         # config = load_test_config()
         setup_hp_ready(1)

--- a/tests/unit/scheduler_test/test_abci_scheduler.py
+++ b/tests/unit/scheduler_test/test_abci_scheduler.py
@@ -1,3 +1,4 @@
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.scheduler import AbciScheduler
 from aiaccel.scheduler import AbciModel
 
@@ -15,13 +16,12 @@ class TestAbciScheduler(BaseTest):
         database_remove
     ):
         database_remove()
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'scheduler'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="scheduler"
+        )
         scheduler = AbciScheduler(options)
         xml_path = data_dir.joinpath('qstat.xml')
         fake_process.register_subprocess(['qstat', '-xml'], stdout=[])
@@ -42,13 +42,12 @@ class TestAbciScheduler(BaseTest):
         database_remove
     ):
         database_remove()
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'scheduler'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="scheduler"
+        )
         scheduler = AbciScheduler(options)
         s = {"name": "run_000005.sh"}
         trial_id = int(scheduler.parse_trial_id(s['name']))
@@ -59,12 +58,11 @@ class TestAbciScheduler(BaseTest):
         assert trial_id is None
 
     def test_create_model(self):
-        options = {
-            'config': self.config_json,
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'scheduler'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="scheduler"
+        )
         scheduler = AbciScheduler(options)
         assert type(scheduler.create_model()) is AbciModel

--- a/tests/unit/test_command_line_options.py
+++ b/tests/unit/test_command_line_options.py
@@ -1,0 +1,15 @@
+from aiaccel.command_line_options import CommandLineOptions
+
+
+class TestCommandLineOptions:
+    def test_init(self) -> None:
+        options = CommandLineOptions(
+            config="config.yaml",
+            resume=0,
+            clean=True,
+            process_name="test"
+        )
+        assert options.config == "config.yaml"
+        assert options.resume == 0
+        assert options.clean is True
+        assert options.process_name == "test"

--- a/tests/unit/test_module.py
+++ b/tests/unit/test_module.py
@@ -7,11 +7,10 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+from aiaccel.command_line_options import CommandLineOptions
 from aiaccel.common import module_type_master
 from aiaccel.common import module_type_optimizer
 from aiaccel.common import module_type_scheduler
-
-
 from aiaccel.master import LocalMaster
 from aiaccel.module import AbstractModule
 from aiaccel.optimizer import RandomOptimizer
@@ -37,34 +36,16 @@ def dummy_break():
     sys.exit()
 
 
-# def test_make_work_directory_exit(config_json, work_dir):
-#     options = {
-#         'config': config_json,
-#         'process_name': 'test'
-#     }
-#     module = AbstractModule(options)
-#     module.logger = logging.getLogger(__name__)
-#     shutil.rmtree(work_dir)
-#     file_create(work_dir.parent.joinpath('work'), "")
-
-#     try:
-#         module.make_work_directory()
-#         assert False
-#     except NotADirectoryError:
-#         assert True
-
-
 class TestAbstractModule(BaseTest):
 
     @pytest.fixture(autouse=True)
     def setup_module(self):
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'test'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="test"
+        )
 
         self.module = AbstractModule(options)
         self.module.logger = logging.getLogger(__name__)
@@ -81,13 +62,12 @@ class TestAbstractModule(BaseTest):
         module_type = self.module.get_module_type()
         assert module_type is None
 
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'fs': False,
-            'process_name': 'master'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="master"
+        )
         commandline_args = [
             "start.py",
             "--config",
@@ -99,24 +79,22 @@ class TestAbstractModule(BaseTest):
             module_type = master.get_module_type()
             assert module_type == module_type_master
 
-            options = {
-                'config': str(self.config_json),
-                'resume': None,
-                'clean': False,
-                'fs': False,
-                'process_name': 'optimizer'
-            }
+            options = CommandLineOptions(
+                config=str(self.config_json),
+                resume=None,
+                clean=False,
+                process_name="optimizer"
+            )
             optimizer = RandomOptimizer(options)
             module_type = optimizer.get_module_type()
             assert module_type == module_type_optimizer
 
-            options = {
-                'config': str(self.config_json),
-                'resume': None,
-                'clean': False,
-                'fs': False,
-                'process_name': 'scheduler'
-            }
+            options = CommandLineOptions(
+                config=str(self.config_json),
+                resume=None,
+                clean=False,
+                process_name="scheduler"
+            )
             scheduler = LocalScheduler(options)
             module_type = scheduler.get_module_type()
             assert module_type == module_type_scheduler
@@ -191,17 +169,17 @@ class TestAbstractModule(BaseTest):
         assert self.module.check_error() is True
 
     def test_resume(self):
-        options = {
-            'config': str(self.config_json),
-            'resume': None,
-            'clean': False,
-            'process_name': 'test'
-        }
+        options = CommandLineOptions(
+            config=str(self.config_json),
+            resume=None,
+            clean=False,
+            process_name="test"
+        )
 
         self.module = AbstractModule(options)
         self.module._rng = np.random.RandomState(0)
         assert self.module.resume() is None
 
-        self.module.options['resume'] = 1
+        self.module.options.resume = 1
         self.module._serialize(1)
         assert self.module.resume() is None


### PR DESCRIPTION
This PR implements dataclass for command line options to remove dict-based option container.
This achieves type annotations for each option such that config is annotated as `config: str`.

```python
# removed
options = {
    "config": AAA,
    "resume": BBB,
    "clean": CCC,
    "process_name": DDD
}

# implemented
options = CommandLineOptions(
    config=AAA,
    resume=BBB,
    clean=CCC,
    process_name=DDD
)
```
