### PR TITLE
Update TypeHint

### DIFF
--- a/aiaccel/cli/csv_writer.py
+++ b/aiaccel/cli/csv_writer.py
@@ -1,7 +1,6 @@
 import csv
 import os
 from logging import StreamHandler, getLogger
-from typing import Union
 
 from fasteners import InterProcessLock
 from omegaconf.dictconfig import DictConfig

--- a/aiaccel/cli/csv_writer.py
+++ b/aiaccel/cli/csv_writer.py
@@ -5,7 +5,6 @@ from typing import Union
 
 from fasteners import InterProcessLock
 from omegaconf.dictconfig import DictConfig
-from omegaconf.listconfig import ListConfig
 
 from aiaccel.storage import Storage
 from aiaccel.util import TrialId
@@ -31,7 +30,7 @@ class CsvWriter:
         lock_file (dict[str, str]): Dict object containing string path to lock.
     """
 
-    def __init__(self, config: Union[ListConfig, DictConfig]):
+    def __init__(self, config: DictConfig):
         self.config = config
         self.workspace = Workspace(self.config.generic.workspace)
         self.fp = self.workspace.retults_csv_file

--- a/aiaccel/cli/plot.py
+++ b/aiaccel/cli/plot.py
@@ -1,6 +1,5 @@
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Union
 
 from omegaconf.dictconfig import DictConfig
 

--- a/aiaccel/cli/plot.py
+++ b/aiaccel/cli/plot.py
@@ -1,9 +1,8 @@
 from argparse import ArgumentParser
 from pathlib import Path
-
 from typing import Union
+
 from omegaconf.dictconfig import DictConfig
-from omegaconf.listconfig import ListConfig
 
 from aiaccel.config import load_config
 from aiaccel.storage.storage import Storage
@@ -23,7 +22,7 @@ class Plotter:
         cplt (EasyVisualizer): EasyVisualizer object.
     """
 
-    def __init__(self, config: Union[ListConfig, DictConfig]):
+    def __init__(self, config: DictConfig):
         self.workspace = Path(config.generic.workspace).resolve()
 
         self.storage = Storage(self.workspace)
@@ -81,7 +80,7 @@ def main() -> None:  # pragma: no cover
     parser.add_argument('--config', '-c', type=str, default="config.yml")
     args = parser.parse_args()
 
-    config: Union[ListConfig, DictConfig] = load_config(args.config)
+    config: DictConfig = load_config(args.config)
 
     if Path(config.generic.workspace).exists() is False:
         print(f"{config.generic.workspace} is not found.")

--- a/aiaccel/cli/view.py
+++ b/aiaccel/cli/view.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 from numpy import maximum
-
 from omegaconf.dictconfig import DictConfig
-from omegaconf.listconfig import ListConfig
 
 from aiaccel.config import load_config
 from aiaccel.storage.storage import Storage
@@ -26,7 +24,7 @@ class Viewer:
         storage (Storage): Storage object.
     """
 
-    def __init__(self, config: Union[ListConfig, DictConfig]) -> None:
+    def __init__(self, config: DictConfig) -> None:
         self.workspace = Path(config.generic.workspace).resolve()
         self.storage = Storage(self.workspace)
 
@@ -114,7 +112,7 @@ def main() -> None:  # pragma: no cover
     parser.add_argument('--config', '-c', type=str, default="config.yml")
     args = parser.parse_args()
 
-    config: Union[ListConfig, DictConfig] = load_config(args.config)
+    config: DictConfig = load_config(args.config)
     workspace = config.generic.workspace
 
     ws = Workspace(workspace)

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from typing import Any, List, Optional, Union
 
 from omegaconf import OmegaConf
+from omegaconf.base import Container
 from omegaconf.dictconfig import DictConfig
 from omegaconf.listconfig import ListConfig
-from omegaconf.base import Container
 
 
 class ResourceType(Enum):
@@ -158,7 +158,7 @@ def set_structs_false(conf: Container) -> None:
                 set_structs_false(conf.__dict__["_content"][item])
 
 
-def load_config(config_path: Path | str) -> Union[ListConfig, DictConfig]:
+def load_config(config_path: Path | str) -> DictConfig:
     """
     Load any configuration files, return the DictConfig object.
     Args:
@@ -179,7 +179,11 @@ def load_config(config_path: Path | str) -> Union[ListConfig, DictConfig]:
     if not isinstance(customize.optimize.goal, ListConfig):
         customize.optimize.goal = ListConfig([customize.optimize.goal])
 
-    config: Union[ListConfig, DictConfig] = OmegaConf.merge(base, default)
+    config = OmegaConf.merge(base, default)
+
+    if not isinstance(config, DictConfig):
+        raise RuntimeError("The configuration is not a DictConfig object.")
+
     set_structs_false(config)
     config = OmegaConf.merge(config, customize)
 

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -163,7 +163,6 @@ def load_config(config_path: Path | str) -> DictConfig:
     Load any configuration files, return the DictConfig object.
     Args:
         config_path (str): A path to a configuration file.
-
     Returns:
         config: DictConfig object
     """
@@ -179,14 +178,11 @@ def load_config(config_path: Path | str) -> DictConfig:
     if not isinstance(customize.optimize.goal, ListConfig):
         customize.optimize.goal = ListConfig([customize.optimize.goal])
 
-    config = OmegaConf.merge(base, default)
-
-    if not isinstance(config, DictConfig):
-        raise RuntimeError("The configuration is not a DictConfig object.")
-
+    config: Union[ListConfig, DictConfig] = OmegaConf.merge(base, default)
     set_structs_false(config)
     config = OmegaConf.merge(config, customize)
-
+    if not isinstance(config, DictConfig):
+        raise RuntimeError("The configuration is not a DictConfig object.")
     return config
 
 

--- a/docs/source/locale/en/LC_MESSAGES/user_guide/configuration_setting.po
+++ b/docs/source/locale/en/LC_MESSAGES/user_guide/configuration_setting.po
@@ -603,15 +603,11 @@ msgid ""
 "HpFinishedFailed. Defaults to 60."
 msgstr ""
 
-<<<<<<< HEAD
-#: ../../source/user_guide/configuration_setting.md:242
-=======
 #: ../../source/user_guide/configuration_setting.md:277
 msgid "job_loop_duration (float, optional):"
 msgstr ""
 
 #: ../../source/user_guide/configuration_setting.md:278
->>>>>>> 6ba7a3c4eb9e7b6925528e0eca5db05c917b9c77
 msgid "スケジューラジョブスレッドのループ 1 周あたりのスリープ時間を秒単位で指定します． デフォルトでは 0.5 (秒) に設定されています．"
 msgstr ""
 

--- a/docs/source/locale/ja/LC_MESSAGES/user_guide/configuration_setting.po
+++ b/docs/source/locale/ja/LC_MESSAGES/user_guide/configuration_setting.po
@@ -603,15 +603,11 @@ msgid ""
 "HpFinishedFailed. Defaults to 60."
 msgstr ""
 
-<<<<<<< HEAD
-#: ../../source/user_guide/configuration_setting.md:242
-=======
 #: ../../source/user_guide/configuration_setting.md:277
 msgid "job_loop_duration (float, optional):"
 msgstr ""
 
 #: ../../source/user_guide/configuration_setting.md:278
->>>>>>> 6ba7a3c4eb9e7b6925528e0eca5db05c917b9c77
 msgid "スケジューラジョブスレッドのループ 1 周あたりのスリープ時間を秒単位で指定します． デフォルトでは 0.5 (秒) に設定されています．"
 msgstr ""
 

--- a/tests/supplements/additional_budget_specified_grid_test.py
+++ b/tests/supplements/additional_budget_specified_grid_test.py
@@ -12,10 +12,8 @@ from aiaccel.common import file_final_result
 from aiaccel.storage.storage import Storage
 from tests.base_test import BaseTest
 from aiaccel.config import load_config
-from typing import Union
 
 from omegaconf.dictconfig import DictConfig
-from omegaconf.listconfig import ListConfig
 
 argnames_test_run = "config_filename, expected_returncode"
 argvalues_test_run = [
@@ -39,7 +37,7 @@ class AdditionalBudgetSpecifiedGridTest(BaseTest):
         yield
         self.test_data_dir = None
 
-    def main(self, config_file: Path) -> tuple[Union[ListConfig, DictConfig], Storage, Popen]:
+    def main(self, config_file: Path) -> tuple[DictConfig, Storage, Popen]:
         config = load_config(config_file)
         python_file = self.test_data_dir.joinpath('user.py')
 


### PR DESCRIPTION
The TypeHint for the Config object has been updated to be more accurate. Specifically, we have changed the typehint for confg from Union[ListConfig, DictConfig] to DictConfig.

<hr>

configイブジェクトのTypeHintをより正確に変更しました．
confg: Union[ListConfig, DictConfig] → typehintをconfg: DictConfig