### PR TITLE
Feature/fix get best trial

### DIFF
--- a/aiaccel/cli/__init__.py
+++ b/aiaccel/cli/__init__.py
@@ -1,6 +1,5 @@
 from aiaccel.cli.csv_writer import CsvWriter
 from aiaccel.cli.plot import Plotter
-from aiaccel.cli.start import get_best_parameter
 from aiaccel.cli.view import Viewer
 
 
@@ -8,5 +7,4 @@ __all__ = [
     'CsvWriter',
     'Plotter',
     'Viewer',
-    'get_best_parameter'
 ]

--- a/aiaccel/cli/start.py
+++ b/aiaccel/cli/start.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import yaml
+from typing import Any
 
 import os
 import pathlib
@@ -11,70 +13,15 @@ from aiaccel.config import load_config
 from pathlib import Path
 
 from aiaccel.cli import CsvWriter
-from aiaccel.common import dict_lock, goal_maximize, goal_minimize
 from aiaccel.master import create_master
 from aiaccel.module import AbstractModule
 from aiaccel.optimizer import create_optimizer
 from aiaccel.scheduler import create_scheduler
-from aiaccel.util import get_file_result_hp, load_yaml
 from aiaccel.workspace import Workspace
 
 logger = getLogger(__name__)
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))
 logger.addHandler(StreamHandler())
-
-
-def get_best_parameter(
-    files: list[Path],
-    goal: str,
-    objective_y_index: int,
-    dict_lock: Path
-) -> tuple[float | None, Path | None]:
-    """Get a best parameter in specified files.
-
-    Args:
-        files (list[Path]): A list of files to find a best.
-        goal (str): Maximize or Minimize.
-        dict_lock (Path): A directory to store lock files.
-
-    Returns:
-        tuple[float | None, Path | None]: A best result value and a
-        file path. It returns None if a number of files is less than one.
-
-    Raises:
-        ValueError: Causes when an invalid goal is set.
-    """
-
-    if len(files) < 1:
-        return None, None
-
-    yml = load_yaml(files[0], dict_lock)
-
-    try:
-        best = float(yml["result"][objective_y_index])
-    except TypeError:
-        logger = getLogger("root.master.parameter")
-        logger.error(f'Invalid result: {yml["result"][objective_y_index]}.')
-        return None, None
-
-    best_file = files[0]
-
-    for f in files[1:]:
-        yml = load_yaml(f, dict_lock)
-        result = float(yml["result"][objective_y_index])
-
-        if goal.lower() == goal_maximize:
-            if best < result:
-                best, best_file = result, f
-        elif goal.lower() == goal_minimize:
-            if best > result:
-                best, best_file = result, f
-        else:
-            logger = getLogger("root.master.parameter")
-            logger.error(f"Invalid goal: {goal}.")
-            raise ValueError(f"Invalid goal: {goal}.")
-
-    return best, best_file
 
 
 def main() -> None:  # pragma: no cover
@@ -94,8 +41,6 @@ def main() -> None:  # pragma: no cover
     config.clean = args.clean
 
     workspace = Workspace(config.generic.workspace)
-    goals = [item.value for item in config.optimize.goal]
-    path_to_lock_file = workspace.path / dict_lock
 
     if config.resume is None:
         if config.clean is True:
@@ -151,12 +96,15 @@ def main() -> None:  # pragma: no cover
     config_name = Path(args.config).name
     shutil.copy(Path(args.config), dst / config_name)
 
-    files = get_file_result_hp(dst)
+    with open(workspace.final_result_file, 'r') as f:
+        final_results: list[dict[str, Any]] = yaml.load(f, Loader=yaml.UnsafeLoader)
 
-    for i in range(len(goals)):
-        best, best_file = get_best_parameter(files, goals[i], i, path_to_lock_file)
-        logger.info(f"Best result [{i}] : {best_file}")
-        logger.info(f"\tvalue : {best}")
+    for i, final_result in enumerate(final_results):
+        best_id = final_result["trial_id"]
+        best_value = final_result["result"][i]
+        if best_id is not None and best_value is not None:
+            logger.info(f"Best result ID [{i}] : {best_id}")
+            logger.info(f"\tvalue : {best_value}")
 
     logger.info(f"Total time [s] : {round(time.time() - time_s)}")
     logger.info("Done.")

--- a/aiaccel/cli/start.py
+++ b/aiaccel/cli/start.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from aiaccel.common import extension_hp
+from aiaccel.common import dict_result
 import yaml
 from typing import Any
 
@@ -103,7 +105,7 @@ def main() -> None:  # pragma: no cover
         best_id = final_result["trial_id"]
         best_value = final_result["result"][i]
         if best_id is not None and best_value is not None:
-            logger.info(f"Best result ID [{i}] : {best_id}")
+            logger.info(f"Best result [{i}] : {dst}/{dict_result}/{best_id}.{extension_hp}")
             logger.info(f"\tvalue : {best_value}")
 
     logger.info(f"Total time [s] : {round(time.time() - time_s)}")

--- a/aiaccel/master/abstract_master.py
+++ b/aiaccel/master/abstract_master.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 from omegaconf.dictconfig import DictConfig
-from aiaccel.common import file_final_result
 from aiaccel.module import AbstractModule
 from aiaccel.util import (create_yaml, get_time_now_object,
                           get_time_string_from_object, str_to_logging_level)
@@ -154,7 +153,8 @@ class AbstractMaster(AbstractModule):
 
         best_trial_ids, _ = self.storage.get_best_trial(self.goals)
         if best_trial_ids is None:
-            raise ValueError("No best trial found.")
+            self.logger.error(f"Failed to output {self.workspace.final_result_file}.")
+            return
 
         hp_results = []
 
@@ -164,5 +164,4 @@ class AbstractMaster(AbstractModule):
         self.logger.info('Best hyperparameter is followings:')
         self.logger.info(hp_results)
 
-        path = self.workspace.result / file_final_result
-        create_yaml(path, hp_results, self.workspace.lock)
+        create_yaml(self.workspace.final_result_file, hp_results, self.workspace.lock)

--- a/aiaccel/master/abstract_master.py
+++ b/aiaccel/master/abstract_master.py
@@ -41,7 +41,6 @@ class AbstractMaster(AbstractModule):
         self.set_logger(
             'root.master',
             self.workspace.log / self.config.logger.file.master,
-            # self.dict_log / self.config.logger.file.master,
             str_to_logging_level(self.config.logger.log_level.master),
             str_to_logging_level(self.config.logger.stream_level.master),
             'Master   '

--- a/aiaccel/storage/storage.py
+++ b/aiaccel/storage/storage.py
@@ -207,6 +207,11 @@ class Storage:
                 return None, None
 
             for i, val in enumerate(values):
+                try:
+                    float(val)
+                except (ValueError, TypeError):
+                    return None, None
+
                 best_value = best_values[i]
                 best_trial_id = best_trial_ids[i]
 

--- a/aiaccel/workspace.py
+++ b/aiaccel/workspace.py
@@ -79,6 +79,7 @@ class Workspace:
         ]
         self.results = Path("./results")
         self.retults_csv_file = self.path / "results.csv"
+        self.final_result_file = self.path / dict_result / "final_result.result"
 
     def create(self) -> bool:
         """Create a work directory.

--- a/tests/unit/storage_test/db/test_storage.py
+++ b/tests/unit/storage_test/db/test_storage.py
@@ -1,3 +1,4 @@
+import numpy as np
 from unittest.mock import patch
 
 from aiaccel.storage import Storage
@@ -537,7 +538,7 @@ def test_get_best_trial_dict():
 def test_get_best_trial():
     storage = Storage(ws.path)
     trial_ids = [0, 1, 2, 3, 4]
-    objectives = [[0.00], [0.01], [-1], [1], [0.03]]
+    objectives = [[0.00], [0.01], [-1], [1], [np.float64(.3)]]
 
     for i in range(len(trial_ids)):
         storage.result.set_any_trial_objective(
@@ -552,6 +553,14 @@ def test_get_best_trial():
     assert storage.get_best_trial(goals) == ([3], [1])
 
     goals = ["aaaaaaaaaa"]
+    assert storage.get_best_trial(goals) == (None, None)
+
+    storage.result.set_any_trial_objective(
+        trial_id=2,
+        objective=[None]
+    )
+
+    goals = ["minimize"]
     assert storage.get_best_trial(goals) == (None, None)
 
 

--- a/tests/unit/test_parameter.py
+++ b/tests/unit/test_parameter.py
@@ -2,67 +2,10 @@ import numpy as np
 import pytest
 
 from aiaccel.parameter import HyperParameterConfiguration
-from aiaccel.cli import get_best_parameter
-from aiaccel.common import dict_lock, dict_result, goal_maximize, goal_minimize
-from aiaccel.util import create_yaml
 from tests.base_test import BaseTest
 
 
 class TestParameter(BaseTest):
-
-    def test_get_best_parameters(
-        self,
-        work_dir,
-        clean_work_dir
-    ):
-        clean_work_dir()
-
-        objective_y_index = 0
-        files = list(work_dir.joinpath(dict_result).glob('*.yml'))
-        best, best_file = get_best_parameter(
-            files,
-            goal_maximize,
-            objective_y_index,
-            work_dir.joinpath(dict_lock)
-        )
-        assert best is None
-        assert best_file is None
-
-        results = [120, 101., np.float64(140.)]
-
-        for i in range(len(self.test_result_data)):
-            d = self.test_result_data[i]
-            name = f"{d['trial_id']}.yml"
-            path = work_dir / 'result' / name
-            d['result'] = [results[i]]
-            create_yaml(path, d)
-
-        files = list(work_dir.joinpath(dict_result).glob('*.yml'))
-        files.sort()
-        best, best_file = get_best_parameter(
-            files,
-            goal_maximize,
-            objective_y_index,
-            work_dir.joinpath(dict_lock)
-        )
-        assert best == 140.
-        best, best_file = get_best_parameter(
-            files,
-            goal_minimize,
-            objective_y_index,
-            work_dir.joinpath(dict_lock)
-        )
-        assert best == 101.
-        try:
-            _, _ = get_best_parameter(
-                files,
-                'invalid_goal',
-                objective_y_index,
-                work_dir.joinpath(dict_lock)
-            )
-            assert False
-        except ValueError:
-            assert True
 
     def test_get_parameter_list(self):
         hp = HyperParameterConfiguration(self.load_config_for_test(self.configs["config.json"]).optimize.parameters)


### PR DESCRIPTION
- aiaccel/storage/storage.py の get_best_trial で ユーザプログラムが数値以外を返した時、数値以外とinfとの比較が起きてTypeErrorが発生する現象を修正しました。
  - 数値比較前に float() で変換し、ValueError, TypeError が発生したらinfとの比較が出来ないため、return None, None して最適解の出力を中断する形に改修しました。
  - ユーザプログラムの出力に数値以外 (None) が含まれている場合のテストを追加しました。
- また、aiaccel/storage/storage.py の get_best_trial と aiaccel/cli/start.py の get_best_parameter とで処理が重複していたため、後者の get_best_parameter 及びそれに関する記述を削除しました。
  - get_best_parameter の代わりに、final_results.result を読み込んで最適解を出力する処理を追加しました。
  - 伴って、最終結果の出力形式が hpファイルのパスを表示する形式から、trial_id を出力する形式に変更しました。（意図してパスを出力している場合は、戻しますのでコメントお願いします。）

改修前
```
moving...
Best result [0] : results/20230411_145803/result/2.hp
	value : 20.53479570832029
Best result [1] : results/20230411_145803/result/1.hp
	value : 16.824019510131414
Total time [s] : 10
Done.
```
改修後
```
moving...
Best result ID [0] : 2
	value : 20.53479570832029
Best result ID [1] : 1
	value : 16.824019510131414
Total time [s] : 10
Done.
```

- ユーザプログラムでエラーが発生し、aiaccelを途中終了しようとした場合にも同様のエラーが発生します。#215 の動作確認中にこちらのTypeError が発覚した経緯があり、#215 の動作確認のためにこちらを先に解決したいと考えています。

close #264 