### PR TITLE
remove q from hyperparameter config

### DIFF
--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -73,7 +73,6 @@ class ParameterConfig:
     initial: Optional[Any]
     choices: Optional[List[Union[None, float, int, str]]]
     sequence: Optional[List[Union[None, float, int, str]]]
-    q: Optional[Union[float, int]]
     log: Optional[bool]
     base: Optional[int]
     step: Optional[Union[int, float]]

--- a/aiaccel/parameter.py
+++ b/aiaccel/parameter.py
@@ -48,7 +48,6 @@ class HyperParameter(object):
             when a parameter type is 'ordinal'.
         initial (float | int | str): A initial value. If this is set, this
             value is evaluated at first run.
-        q (float | int): A quantization factor.
     """
 
     def __init__(self, parameter: dict[str, Any]) -> None:
@@ -61,7 +60,6 @@ class HyperParameter(object):
         self.choices = parameter.get('choices', None)
         self.sequence = parameter.get('sequence', None)
         self.initial = parameter.get('initial', None)
-        self.q = parameter.get('q', 1)
         self.step = parameter.get('step', None)
         self.base = parameter.get('base', None)
         self.num_numeric_choices = parameter.get('num_numeric_choices', None)


### PR DESCRIPTION
This PR removes `q` (quantization number of numerical hyperparameter) since it is not used.