### PR TITLE
Update Storage class constructor to use database path instead of workspace path

### DIFF
--- a/aiaccel/cli/csv_writer.py
+++ b/aiaccel/cli/csv_writer.py
@@ -34,7 +34,7 @@ class CsvWriter:
         self.workspace = Workspace(self.config.generic.workspace)
         self.fp = self.workspace.retults_csv_file
         self.trialid = TrialId(self.config)
-        self.storage = Storage(self.workspace.path)
+        self.storage = Storage(self.workspace.storage_file_path)
         self.lock_file = {'result_txt': str(self.workspace.lock / 'result_txt')}
 
     def _get_zero_padding_trial_id(self, trial_id: int) -> str:

--- a/aiaccel/cli/plot.py
+++ b/aiaccel/cli/plot.py
@@ -6,6 +6,7 @@ from omegaconf.dictconfig import DictConfig
 from aiaccel.config import load_config
 from aiaccel.storage.storage import Storage
 from aiaccel.util.easy_visualizer import EasyVisualizer
+from aiaccel.workspace import Workspace
 
 
 class Plotter:
@@ -15,16 +16,15 @@ class Plotter:
         config (Config): Config object.
 
     Attributes:
-        workspace (Path): Path to the workspace.
+        workspace (Workspace): Workspace object.
         storage (Storage): Storage object.
         goar (str): Goal of optimization ('minimize' or 'maximize').
         cplt (EasyVisualizer): EasyVisualizer object.
     """
 
     def __init__(self, config: DictConfig):
-        self.workspace = Path(config.generic.workspace).resolve()
-
-        self.storage = Storage(self.workspace)
+        self.workspace = Workspace(config.generic.workspace)
+        self.storage = Storage(self.workspace.storage_file_path)
         self.goals = [item.value for item in config.optimize.goal]
 
         self.cplt = EasyVisualizer()

--- a/aiaccel/cli/view.py
+++ b/aiaccel/cli/view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from pathlib import Path
 from typing import Any
 
 from numpy import maximum
@@ -20,13 +19,13 @@ class Viewer:
 
     Attributes:
         config_path (Path): Path to the config file.
-        workspace (Path): Path to the workspace.
+        workspace (Workspace): Workspace object.
         storage (Storage): Storage object.
     """
 
     def __init__(self, config: DictConfig) -> None:
-        self.workspace = Path(config.generic.workspace).resolve()
-        self.storage = Storage(self.workspace)
+        self.workspace = Workspace(config.generic.workspace)
+        self.storage = Storage(self.workspace.storage_file_path)
 
     def view(self) -> None:
         """Print database information

--- a/aiaccel/master/evaluator/abstract_evaluator.py
+++ b/aiaccel/master/evaluator/abstract_evaluator.py
@@ -27,7 +27,7 @@ class AbstractEvaluator(object):
         storage (Storage): Storage object.
         goals (list[str]): Goal of optimization ('minimize' or 'maximize').
         trial_id (TrialId): TrialId object.
-
+        workspace (Workspace): Workspace object.
     """
     def __init__(self, config: DictConfig) -> None:
         """Initial method for AbstractEvaluator.
@@ -38,7 +38,7 @@ class AbstractEvaluator(object):
         self.config = config
         self.workspace = Workspace(self.config.generic.workspace)
         self.hp_result: list[dict[str, Any]] | None = None
-        self.storage = Storage(self.workspace.path)
+        self.storage = Storage(self.workspace.storage_file_path)
         self.goals = [item.value for item in self.config.optimize.goal]
         self.trial_id = TrialId(self.config)
 

--- a/aiaccel/module.py
+++ b/aiaccel/module.py
@@ -64,7 +64,7 @@ class AbstractModule(object):
         self.hp_running = 0
         self.hp_finished = 0
         self.seed = self.config.optimize.rand_seed
-        self.storage = Storage(self.workspace.path)
+        self.storage = Storage(self.workspace.storage_file_path)
         self.trial_id = TrialId(self.config)
         # TODO: Separate the generator if don't want to affect randomness each other.
         self._rng = np.random.RandomState(self.seed)

--- a/aiaccel/scheduler/job/job.py
+++ b/aiaccel/scheduler/job/job.py
@@ -581,7 +581,7 @@ class Job:
         self.proc: Any = None
         self.th_oh: Any = None
         self.stop_flag = False
-        self.storage = Storage(self.workspace.path)
+        self.storage = Storage(self.workspace.storage_file_path)
         self.content = self.storage.get_hp_dict(self.trial_id)
         self.result_file_path = self.workspace.result / (self.trial_id_str + '.hp')
         self.expirable_states = [jt["source"] for jt in JOB_TRANSITIONS if jt["trigger"] == "expire"]

--- a/aiaccel/storage/storage.py
+++ b/aiaccel/storage/storage.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from aiaccel.common import dict_storage
 from aiaccel.storage import (Error, Hp, JobState, Result, Serializer,
                              TimeStamp, Trial)
 
@@ -12,15 +11,15 @@ class Storage:
     """Database
     """
 
-    def __init__(self, ws: Path) -> None:
-        db_path = ws / dict_storage / "storage.db"
-        self.trial = Trial(db_path)
-        self.hp = Hp(db_path)
-        self.result = Result(db_path)
-        self.jobstate = JobState(db_path)
-        self.error = Error(db_path)
-        self.timestamp = TimeStamp(db_path)
-        self.variable = Serializer(db_path)
+    def __init__(self, _db_path: Path | str) -> None:
+        self.db_path = Path(_db_path)
+        self.trial = Trial(self.db_path)
+        self.hp = Hp(self.db_path)
+        self.result = Result(self.db_path)
+        self.jobstate = JobState(self.db_path)
+        self.error = Error(self.db_path)
+        self.timestamp = TimeStamp(self.db_path)
+        self.variable = Serializer(self.db_path)
 
     def current_max_trial_number(self) -> int | None:
         """Get the current maximum number of trials.

--- a/aiaccel/workspace.py
+++ b/aiaccel/workspace.py
@@ -81,6 +81,7 @@ class Workspace:
         ]
         self.results = Path("./results")
         self.retults_csv_file = self.path / "results.csv"
+        self.storage_file_path = self.storage / "storage.db"
 
     def create(self) -> bool:
         """Create a work directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,11 @@ from pathlib import Path
 
 import fasteners
 import pytest
+
 from aiaccel.config import load_config
-from aiaccel.workspace import Workspace
 from aiaccel.storage import Storage
 from aiaccel.util import create_yaml, interprocess_lock_file, load_yaml
+from aiaccel.workspace import Workspace
 
 WORK_SUB_DIRECTORIES = [
     'abci_output', 'alive', 'hp', 'hp/finished', 'hp/ready', 'hp/running',
@@ -180,8 +181,8 @@ def create_tmp_config(data_dir, tmpdir, work_dir):
             with open(tmp_conf_path, 'w') as f:
                 json.dump(json_obj, f)
 
-        ws = Workspace(str(work_dir))
-        ws.create()
+        workspace = Workspace(str(work_dir))
+        workspace.create()
 
         return tmp_conf_path
 
@@ -202,8 +203,8 @@ def setup_hp_files(work_dir):
         #         data_dir.joinpath('work/hp/finished/{:03}.hp'.format(i)),
         #         work_dir.joinpath('hp/{}/{:03}.hp'.format(hp_type, i))
         #     )
-
-        storage = Storage(work_dir)
+        workspace = Workspace(str(work_dir))
+        storage = Storage(workspace.storage_file_path)
         for i in range(n):
             storage.trial.set_any_trial_state(trial_id=i, state=hp_type)
     return _setup_hp_files
@@ -236,7 +237,8 @@ def setup_hp_finished(setup_hp_files):
 @pytest.fixture(scope="session")
 def setup_result(work_dir):
     def _setup_result(n=1):
-        storage = Storage(work_dir)
+        workspace = Workspace(str(work_dir))
+        storage = Storage(workspace.storage_file_path)
         running = storage.get_running()
         for trial_id in running:
             storage.result.set_any_trial_objective(trial_id=trial_id, objective=[0])
@@ -247,9 +249,9 @@ def setup_result(work_dir):
 @pytest.fixture(scope="session")
 def database_remove(work_dir):
     def _database_remove():
-        p = work_dir / 'storage' / 'storage.db'
-        if p.exists():
-            p.unlink()
+        workspace = Workspace(str(work_dir))
+        if workspace.storage_file_path.exists():
+            workspace.storage_file_path.unlink()
     return _database_remove
 
 

--- a/tests/resumption/resumption_test.py
+++ b/tests/resumption/resumption_test.py
@@ -1,10 +1,10 @@
 import subprocess
 from pathlib import Path
 
-from aiaccel.storage import Storage
-from tests.integration.integration_test import IntegrationTest
-
 from aiaccel.config import is_multi_objective
+from aiaccel.storage import Storage
+from aiaccel.workspace import Workspace
+from tests.integration.integration_test import IntegrationTest
 
 
 class ResumptionTest(IntegrationTest):
@@ -21,7 +21,8 @@ class ResumptionTest(IntegrationTest):
             user_main_file = None
 
         with self.create_main(user_main_file):
-            storage = Storage(ws=Path(config.generic.workspace))
+            workspace = Workspace(config.generic.workspace)
+            storage = Storage(workspace.storage_file_path)
             subprocess.Popen(['aiaccel-start', '--config', str(config.config_path), '--clean']).wait()
 
             final_result_at_one_time = self.get_final_result(storage)
@@ -40,7 +41,8 @@ class ResumptionTest(IntegrationTest):
             config = self.load_config_for_test(
                 self.configs['config_{}.json'.format(self.search_algorithm)]
             )
-            storage = Storage(ws=Path(config.generic.workspace))
+            workspace = Workspace(config.generic.workspace)
+            storage = Storage(workspace.storage_file_path)
             subprocess.Popen(['aiaccel-start', '--config', str(config.config_path), '--resume', '3']).wait()
             final_result_resumption = self.get_final_result(storage)
             print('resumption steps finished', final_result_resumption)

--- a/tests/supplements/additional_budget_specified_grid_test.py
+++ b/tests/supplements/additional_budget_specified_grid_test.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from subprocess import Popen
 
 import pytest
-
-from aiaccel.common import dict_result
-from aiaccel.common import file_final_result
-from aiaccel.storage.storage import Storage
-from tests.base_test import BaseTest
-from aiaccel.config import load_config
-
 from omegaconf.dictconfig import DictConfig
+
+from aiaccel.common import dict_result, file_final_result
+from aiaccel.config import load_config
+from aiaccel.storage.storage import Storage
+from aiaccel.workspace import Workspace
+from tests.base_test import BaseTest
 
 argnames_test_run = "config_filename, expected_returncode"
 argvalues_test_run = [
@@ -40,9 +38,10 @@ class AdditionalBudgetSpecifiedGridTest(BaseTest):
     def main(self, config_file: Path) -> tuple[DictConfig, Storage, Popen]:
         config = load_config(config_file)
         python_file = self.test_data_dir.joinpath('user.py')
-
+        workspace = Workspace(config.generic.workspace)
+        storage = Storage(workspace.storage_file_path)
         with self.create_main(python_file):
-            storage = Storage(ws=Path(config.generic.workspace))
+            # storage = Storage(ws=Path(config.generic.workspace))
             popen = Popen(
                 ['aiaccel-start', '--config', str(config_file), '--clean']
             )

--- a/tests/supplements/additional_grid_test.py
+++ b/tests/supplements/additional_grid_test.py
@@ -3,11 +3,10 @@
 import subprocess
 from pathlib import Path
 
+from aiaccel.common import dict_result, file_final_result
 from aiaccel.config import load_config
-from aiaccel.common import dict_result
-from aiaccel.common import file_final_result
 from aiaccel.storage import Storage
-
+from aiaccel.workspace import Workspace
 from tests.base_test import BaseTest
 
 
@@ -18,20 +17,22 @@ class AdditionalGridTest(BaseTest):
         test_data_dir = Path(__file__).resolve().parent.joinpath('additional_grid_test', 'test_data')
         config_file = test_data_dir.joinpath('config_{}.yaml'.format(self.search_algorithm))
         config_file = create_tmp_config(config_file)
-        self.config = load_config(config_file)
+        config = load_config(config_file)
         python_file = test_data_dir.joinpath('user.py')
 
-        with self.create_main(python_file):
-            storage = Storage(ws=Path(self.config.generic.workspace))
-            subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']
-                             ).wait(timeout=self.config.generic.batch_job_timeout)
-        self.evaluate(work_dir, storage)
+        workspace = Workspace(config.generic.workspace)
+        storage = Storage(workspace.storage_file_path)
 
-    def evaluate(self, work_dir, storage):
+        with self.create_main(python_file):
+            subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']
+                             ).wait(timeout=config.generic.batch_job_timeout)
+        self.evaluate(work_dir, storage, config)
+
+    def evaluate(self, work_dir, storage, config):
         running = storage.get_num_running()
         ready = storage.get_num_ready()
         finished = storage.get_num_finished()
-        assert finished == self.config.optimize.trial_number
+        assert finished == config.optimize.trial_number
         assert ready == 0
         assert running == 0
         final_result = work_dir.joinpath(dict_result, file_final_result)

--- a/tests/supplements/additional_nums_node_trial_test.py
+++ b/tests/supplements/additional_nums_node_trial_test.py
@@ -55,15 +55,15 @@ class AdditionalNumsNodeTrialTest(BaseTest):
         cfg['optimize']['trial_number'] = num_trial
         with open(config_file, 'w') as f:
             yaml.dump(cfg, f, default_flow_style=False)
-        config_file = create_tmp_config(self.config_file)
-        config = load_config(self.config_file)
+        config_file = create_tmp_config(config_file)
+        config = load_config(config_file)
 
         workspace = Workspace(config.generic.workspace)
         storage = Storage(workspace.storage_file_path)
 
         with self.create_main(self.python_file):
             popen = Popen(
-                ['aiaccel-start', '--config', str(self.config_file), '--clean']
+                ['aiaccel-start', '--config', str(config_file), '--clean']
             )
             popen.wait(timeout=config.generic.batch_job_timeout)
         self.evaluate(work_dir, config, storage)

--- a/tests/supplements/additional_resumption_test.py
+++ b/tests/supplements/additional_resumption_test.py
@@ -9,8 +9,8 @@ import subprocess
 from pathlib import Path
 
 from aiaccel.config import load_config
-
 from aiaccel.storage import Storage
+from aiaccel.workspace import Workspace
 from tests.integration.integration_test import IntegrationTest
 
 
@@ -24,16 +24,17 @@ class AdditionalResumptionTest(IntegrationTest):
         config = load_config(config_file)
         python_file = test_data_dir.joinpath('user.py')
 
+        workspace = Workspace(config.generic.workspace)
+        storage = Storage(workspace.storage_file_path)
+
         # normal execution
         with self.create_main(python_file):
-            storage = Storage(ws=Path(config.generic.workspace))
             subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']).wait()
             final_result_at_one_time = self.get_final_result(storage)
         print('at one time', final_result_at_one_time)
 
         # resume from initial point
         with self.create_main(python_file):
-            storage = Storage(ws=Path(config.generic.workspace))
             subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--resume', '2']).wait()
             final_result_resumption_in_initial = self.get_final_result(storage)
         print('resumption steps in initial point finished', final_result_resumption_in_initial)
@@ -42,7 +43,6 @@ class AdditionalResumptionTest(IntegrationTest):
 
         # resume after initial point
         with self.create_main(python_file):
-            storage = Storage(ws=Path(config.generic.workspace))
             subprocess.Popen(['aiaccel-start', '--config', str(config_file),
                               '--resume', '11']).wait()
             final_result_resumption = self.get_final_result(storage)

--- a/tests/supplements/no_initial_test.py
+++ b/tests/supplements/no_initial_test.py
@@ -3,12 +3,10 @@
 import subprocess
 from pathlib import Path
 
+from aiaccel.common import dict_result, file_final_result
 from aiaccel.config import load_config
-
-from aiaccel.common import dict_result
-from aiaccel.common import file_final_result
 from aiaccel.storage import Storage
-
+from aiaccel.workspace import Workspace
 from tests.base_test import BaseTest
 
 
@@ -19,20 +17,22 @@ class NoInitialTest(BaseTest):
         test_data_dir = Path(__file__).resolve().parent.joinpath('no_initial_test_benchmark', 'test_data')
         config_file = test_data_dir.joinpath('config_{}.yaml'.format(self.search_algorithm))
         config_file = create_tmp_config(config_file)
-        self.config = load_config(config_file)
+        config = load_config(config_file)
         python_file = test_data_dir.joinpath('user.py')
 
-        with self.create_main(python_file):
-            storage = Storage(ws=Path(self.config.generic.workspace))
-            subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']
-                             ).wait(timeout=self.config.generic.batch_job_timeout)
-        self.evaluate(work_dir, storage)
+        workspace = Workspace(config.generic.workspace)
+        storage = Storage(workspace.storage_file_path)
 
-    def evaluate(self, work_dir, storage):
+        with self.create_main(python_file):
+            subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']
+                             ).wait(timeout=config.generic.batch_job_timeout)
+        self.evaluate(work_dir, config, storage)
+
+    def evaluate(self, work_dir, config, storage):
         running = storage.get_num_running()
         ready = storage.get_num_ready()
         finished = storage.get_num_finished()
-        assert finished == self.config.optimize.trial_number
+        assert finished == config.optimize.trial_number
         assert ready == 0
         assert running == 0
         final_result = work_dir.joinpath(dict_result, file_final_result)

--- a/tests/supplements/random_generation_test.py
+++ b/tests/supplements/random_generation_test.py
@@ -4,8 +4,8 @@ import subprocess
 from pathlib import Path
 
 from aiaccel.config import load_config
-
 from aiaccel.storage import Storage
+from aiaccel.workspace import Workspace
 from tests.base_test import BaseTest
 
 
@@ -21,8 +21,10 @@ class RandomGenerationTest(BaseTest):
         config_file = create_tmp_config(config_file)
         config = load_config(config_file)
 
+        workspace = Workspace(config.generic.workspace)
+        storage = Storage(workspace.storage_file_path)
+
         with self.create_main(python_file):
-            storage = Storage(ws=Path(config.generic.workspace))
             subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']).wait()
         final_result_random = self.get_final_result(storage)
         print('random', final_result_random)
@@ -32,8 +34,10 @@ class RandomGenerationTest(BaseTest):
         config_file = create_tmp_config(config_file)
         config = load_config(config_file)
 
+        workspace = Workspace(config.generic.workspace)
+        storage = Storage(workspace.storage_file_path)
+
         with self.create_main(python_file):
-            storage = Storage(ws=Path(config.generic.workspace))
             subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']).wait()
         final_result_tpe = self.get_final_result(storage)
         print('tpe', final_result_tpe)
@@ -45,8 +49,10 @@ class RandomGenerationTest(BaseTest):
         config_file = create_tmp_config(config_file)
         config = load_config(config_file)
 
+        workspace = Workspace(config.generic.workspace)
+        storage = Storage(workspace.storage_file_path)
+
         with self.create_main(python_file):
-            storage = Storage(ws=Path(config.generic.workspace))
             subprocess.Popen(['aiaccel-start', '--config', str(config_file), '--clean']).wait()
         final_result_neldermead = self.get_final_result(storage)
         print('nelder-mead', final_result_neldermead)

--- a/tests/unit/cli_test/test_plot.py
+++ b/tests/unit/cli_test/test_plot.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from aiaccel.config import load_config
 from aiaccel.cli import Plotter
+from aiaccel.config import load_config
 from aiaccel.storage import Storage
 from aiaccel.workspace import Workspace
 
@@ -18,8 +18,6 @@ def test_plot(clean_work_dir, work_dir, create_tmp_config):
     config_path = Path('tests/test_data/config.json')
     config_path = create_tmp_config(config_path)
     config = load_config(config_path)
-    storage = Storage(ws=Path(config.generic.workspace))
-
     config.optimize.goal = ["minimize"]
 
     # データ無しの場合
@@ -30,6 +28,7 @@ def test_plot(clean_work_dir, work_dir, create_tmp_config):
     trial_id = 0
     objective = [0.01]
 
+    storage = Storage(workspace.storage_file_path)
     storage.result.set_any_trial_objective(
         trial_id=trial_id,
         objective=objective

--- a/tests/unit/cli_test/view_test/test_view.py
+++ b/tests/unit/cli_test/view_test/test_view.py
@@ -1,9 +1,8 @@
 
-from aiaccel.config import load_config
-
 from pathlib import Path
 
 from aiaccel.cli.view import Viewer
+from aiaccel.config import load_config
 from aiaccel.storage import Storage
 from aiaccel.workspace import Workspace
 
@@ -18,7 +17,9 @@ def test_view(clean_work_dir, work_dir, create_tmp_config):
     config_path = Path('tests/test_data/config.json')
     config_path = create_tmp_config(config_path)
     config = load_config(config_path)
-    storage = Storage(ws=Path(config.generic.workspace))
+
+    workspace = Workspace(config.generic.workspace)
+    storage = Storage(workspace.storage_file_path)
 
     trial_id = 5
     objective = 42.0

--- a/tests/unit/optimizer_test/test_nelder_mead.py
+++ b/tests/unit/optimizer_test/test_nelder_mead.py
@@ -4,9 +4,10 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from aiaccel.parameter import HyperParameterConfiguration
 from aiaccel.optimizer import NelderMead
+from aiaccel.parameter import HyperParameterConfiguration
 from aiaccel.storage import Storage
+from aiaccel.workspace import Workspace
 from tests.base_test import BaseTest
 
 
@@ -84,7 +85,9 @@ class TestNelderMead(BaseTest):
         for p, i in zip(params, range(1, len(self.nm.bdrys)+2)):
             p['vertex_id'] = '{:03}'.format(i)
 
-        storage = Storage(work_dir)
+        workspace = Workspace(work_dir)
+        storage = Storage(workspace.storage_file_path)
+
         setup_hp_finished(1)
         for i in range(1):
             storage.result.set_any_trial_objective(trial_id=i, objective=0.0)

--- a/tests/unit/storage_test/db/base.py
+++ b/tests/unit/storage_test/db/base.py
@@ -1,8 +1,9 @@
 import pathlib
+import time
 from functools import wraps
 
+from aiaccel.storage import Storage
 from aiaccel.workspace import Workspace
-import time
 
 ws = Workspace("test_work")
 db_path = (ws.path / 'storage/storage.db')
@@ -24,6 +25,9 @@ def init():
 def create():
     ws.create()
 
+def get_storage():
+    storage = Storage(ws.storage_file_path)
+    return storage
 
 def t_base():
     def _test_base(func):

--- a/tests/unit/storage_test/db/test_error.py
+++ b/tests/unit/storage_test/db/test_error.py
@@ -3,14 +3,14 @@ from sqlalchemy.exc import SQLAlchemyError
 from undecorated import undecorated
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import t_base, ws, init
+from tests.unit.storage_test.db.base import get_storage, init, t_base, ws
 
 # set_any_trial_error
 
 
 @t_base()
 def test_set_any_trial_error():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     message = "hoge"
@@ -29,7 +29,7 @@ def test_set_any_trial_error():
 # set_any_trial_error exception
 @t_base()
 def test_set_any_trial_error_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     message = "hoge"
@@ -43,7 +43,7 @@ def test_set_any_trial_error_exception():
 # get_any_trial_error
 @t_base()
 def test_get_any_trial_error():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     message = "hoge"
@@ -59,9 +59,9 @@ def test_get_any_trial_error():
 # get_error_trial_id
 @t_base()
 def test_get_error_trial_id():
-    storage = Storage(ws.path)
-    assert storage.error.get_error_trial_id() == []
+    storage = get_storage()
 
+    assert storage.error.get_error_trial_id() == []
     assert storage.error.get_error_trial_id() == []
 
     ids = [0, 1, 2]
@@ -83,7 +83,7 @@ def test_get_error_trial_id():
 # all_delete
 @t_base()
 def test_all_delete():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     ids = [0, 1, 2]
     mess = [
@@ -106,7 +106,7 @@ def test_all_delete():
 # all_delete
 @t_base()
 def test_all_delete_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     ids = [0, 1, 2]
     mess = [
@@ -130,7 +130,7 @@ def test_all_delete_exception():
 # delete_any_trial_error
 @t_base()
 def test_delete_any_trial_error():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     ids = [0, 1, 2]
     messages = ["hoge0", "hoge1", "hoge2"]
@@ -164,7 +164,7 @@ def test_delete_any_trial_error():
 # delete_any_trial_error exception
 @t_base()
 def test_delete_any_trial_error_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     ids = [0, 1, 2]
     messages = ["hoge0", "hoge1", "hoge2"]

--- a/tests/unit/storage_test/db/test_hp.py
+++ b/tests/unit/storage_test/db/test_hp.py
@@ -1,16 +1,16 @@
 import pytest
-from undecorated import undecorated
 from sqlalchemy.exc import SQLAlchemyError
+from undecorated import undecorated
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import t_base, ws
+from tests.unit.storage_test.db.base import get_storage, t_base, ws
 
 # set_any_trial_param
 
 
 @t_base()
 def test_set_any_trial_param():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     param_name = "x1"
@@ -28,7 +28,7 @@ def test_set_any_trial_param():
 # set_any_trial_param exception
 @t_base()
 def test_set_any_trial_param():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     param_name = "x1"
@@ -50,7 +50,7 @@ def test_set_any_trial_param():
 # set_any_trial_param
 @t_base()
 def test_set_any_trial_params():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     params = [
@@ -89,7 +89,7 @@ def test_set_any_trial_params():
 # set_any_trial_param exception
 @t_base()
 def test_set_any_trial_params_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     params = [
@@ -133,7 +133,7 @@ def test_set_any_trial_params_exception():
 # get_any_trial_params
 @t_base()
 def test_get_any_trial_params():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     param_name = "x1"
@@ -166,7 +166,7 @@ def test_get_any_trial_params():
 # all_delete
 @t_base()
 def test_all_delete():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     param_name = "x1"
@@ -187,7 +187,7 @@ def test_all_delete():
 # all_delete exception
 @t_base()
 def test_all_delete_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     param_name = "x1"
@@ -211,7 +211,7 @@ def test_all_delete_exception():
 
 @t_base()
 def test_delete_any_trial_params():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     params = [
@@ -290,7 +290,7 @@ def test_delete_any_trial_params():
 # delete_any_trial_params exception
 @t_base()
 def test_delete_any_trial_params_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     (ws.path / 'storage/storage.db').unlink()
     with pytest.raises(SQLAlchemyError):

--- a/tests/unit/storage_test/db/test_jobstate.py
+++ b/tests/unit/storage_test/db/test_jobstate.py
@@ -1,15 +1,15 @@
 import pytest
-from undecorated import undecorated
 from sqlalchemy.exc import SQLAlchemyError
+from undecorated import undecorated
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import t_base, ws
+from tests.unit.storage_test.db.base import get_storage, t_base, ws
 
 
 # set_any_trial_param
 @t_base()
 def test_set_any_trial_jobstate():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     state = "test_state"
@@ -29,7 +29,7 @@ def test_set_any_trial_jobstate():
 # set_any_trial_param exception
 @t_base()
 def test_set_any_trial_jobstate_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     state = "test_state"
@@ -47,7 +47,7 @@ def test_set_any_trial_jobstate_exception():
 # get_any_trial_jobstate
 @t_base()
 def test_get_any_trial_jobstate():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     state = "test_state"
@@ -72,7 +72,7 @@ def test_get_any_trial_jobstate():
 # set_any_trial_jobstates
 @t_base()
 def test_set_any_trial_jobstates():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         {'trial_id': 0, 'jobstate': 'stata_0'},
@@ -93,7 +93,7 @@ def test_set_any_trial_jobstates():
 # set_any_trial_jobstates exception
 @t_base()
 def test_set_any_trial_jobstates_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         {'trial_id': 0, 'jobstate': 'stata_0'},
@@ -112,7 +112,7 @@ def test_set_any_trial_jobstates_exception():
 # get_all_trial_jobstate
 @t_base()
 def test_get_all_trial_jobstate():
-    storage = Storage(ws.path)
+    storage = get_storage()
     print(storage.jobstate.get_all_trial_jobstate())
     assert storage.jobstate.get_all_trial_jobstate() == [{'trial_id': None, 'jobstate': None}]
 
@@ -133,7 +133,7 @@ def test_get_all_trial_jobstate():
 
 @t_base()
 def test_is_failure():
-    storage = Storage(ws.path)
+    storage = get_storage()
     test_states = [
         'RunnerFailure',
         'HpRunningFailure',
@@ -166,7 +166,7 @@ def test_is_failure():
 
 @t_base()
 def test_delete_any_trial_jobstate():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     state = "test_state_0"
@@ -212,7 +212,7 @@ def test_delete_any_trial_jobstate():
 # delete_any_trial_jobstate exception
 @t_base()
 def test_delete_any_trial_jobstate_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     state = "test_state_0"

--- a/tests/unit/storage_test/db/test_result.py
+++ b/tests/unit/storage_test/db/test_result.py
@@ -6,13 +6,13 @@ from sqlalchemy.exc import SQLAlchemyError
 from undecorated import undecorated
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import init, t_base, ws
+from tests.unit.storage_test.db.base import init, t_base, ws, get_storage
 
 
 # set_any_trial_objective
 @t_base()
 def test_set_any_trial_objective():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -34,7 +34,7 @@ def test_set_any_trial_objective():
 
 @t_base()
 def test_set_any_trial_objective_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -51,7 +51,7 @@ def test_set_any_trial_objective_exception():
 @t_base()
 def test_get_any_trial_objective_and_best_value():
 
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     # Test when objectives is None
     trial_id = 1
@@ -77,7 +77,7 @@ def test_get_any_trial_objective_and_best_value():
 # get_any_trial_objective
 @t_base()
 def test_get_any_trial_objective():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -94,7 +94,7 @@ def test_get_any_trial_objective():
 # get_all_result
 @t_base()
 def test_get_all_result():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     objectives = [1, 2, 3, 1.23]
     ids = range(len(objectives))
@@ -112,7 +112,7 @@ def test_get_all_result():
 # get_objectives
 @t_base()
 def test_get_objectives():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     objectives = [1, 2, 3, 1.23]
     ids = range(len(objectives))
@@ -129,7 +129,7 @@ def test_get_objectives():
 
 @t_base()
 def test_get_bests():
-    storage = Storage(ws.path)
+    storage = get_storage()
     objectives = [[1], [-5], [3], [1.23]]
     ids = range(len(objectives))
 
@@ -154,7 +154,7 @@ def test_get_bests():
 # get_result_trial_id_list
 @t_base()
 def test_get_result_trial_id_list():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     assert storage.result.get_result_trial_id_list() is None
 
@@ -173,7 +173,7 @@ def test_get_result_trial_id_list():
 # all_delete
 @t_base()
 def test_all_delete():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     objectives = [1, 2, 3, 1.23]
     ids = range(len(objectives))
@@ -192,7 +192,7 @@ def test_all_delete():
 # all_delete exception
 @t_base()
 def test_all_delete_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     objectives = [1, 2, 3, 1.23]
     ids = range(len(objectives))
@@ -212,7 +212,7 @@ def test_all_delete_exception():
 # delete_any_trial_objective
 @t_base()
 def test_delete_any_trial_objective():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     ids = [0, 1, 2]
     objectives = [0.01, 0.02, 0.03]
@@ -246,7 +246,7 @@ def test_delete_any_trial_objective():
 # delete_any_trial_objective exception
 @t_base()
 def test_delete_any_trial_objective_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     ids = [0, 1, 2]
     objectives = [0.01, 0.02, 0.03]

--- a/tests/unit/storage_test/db/test_storage.py
+++ b/tests/unit/storage_test/db/test_storage.py
@@ -1,13 +1,13 @@
 from unittest.mock import patch
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import t_base, ws
+from tests.unit.storage_test.db.base import get_storage, t_base, ws
 
 
 # set_any_trial_start_time
 @t_base()
 def test_current_max_trial_number():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     assert storage.current_max_trial_number() is None
 
@@ -24,7 +24,7 @@ def test_current_max_trial_number():
 # get_ready
 @t_base()
 def test_get_ready():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -47,7 +47,7 @@ def test_get_ready():
 # get_running
 @t_base()
 def test_get_running():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -70,7 +70,7 @@ def test_get_running():
 # get_finished
 @t_base()
 def test_get_finished():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -93,7 +93,7 @@ def test_get_finished():
 # get_num_ready
 @t_base()
 def test_get_num_ready():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -119,7 +119,7 @@ def test_get_num_ready():
 # get_num_running
 @t_base()
 def test_get_num_running():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -145,7 +145,7 @@ def test_get_num_running():
 # get_num_finished
 @t_base()
 def test_get_num_finished():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -171,7 +171,7 @@ def test_get_num_finished():
 # is_ready
 @t_base()
 def test_is_ready():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -201,7 +201,7 @@ def test_is_ready():
 # is_running
 @t_base()
 def test_is_running():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -231,7 +231,7 @@ def test_is_running():
 # is_finished
 @t_base()
 def test_is_finished():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -261,7 +261,7 @@ def test_is_finished():
 # get_hp_dict
 @t_base()
 def test_get_hp_dict():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -309,7 +309,7 @@ def test_get_hp_dict():
 # get_hp_dict
 @t_base()
 def test_get_hp_dict_int():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -356,7 +356,7 @@ def test_get_hp_dict_int():
 
 @t_base()
 def test_get_hp_dict_categorical():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -402,7 +402,7 @@ def test_get_hp_dict_categorical():
 
 @t_base()
 def test_get_hp_dict_invalid_type():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -449,7 +449,7 @@ def test_get_hp_dict_invalid_type():
 # get_result_and_error
 @t_base()
 def test_get_result_and_error():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -471,7 +471,7 @@ def test_get_result_and_error():
 # get_best_trial_dict
 @t_base()
 def test_get_best_trial_dict():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     objective = 0.01
@@ -535,7 +535,7 @@ def test_get_best_trial_dict():
 # get_best_trial
 @t_base()
 def test_get_best_trial():
-    storage = Storage(ws.path)
+    storage = get_storage()
     trial_ids = [0, 1, 2, 3, 4]
     objectives = [[0.00], [0.01], [-1], [1], [0.03]]
 
@@ -558,7 +558,7 @@ def test_get_best_trial():
 # delete_trial_data_after_this
 @t_base()
 def test_delete_trial_data_after_this():
-    storage = Storage(ws.path)
+    storage = get_storage()
     assert storage.delete_trial_data_after_this(trial_id=1) is None
 
     def dummy_delete_trial(trial_id: int) -> None:
@@ -572,14 +572,14 @@ def test_delete_trial_data_after_this():
 # delete_trial
 @t_base()
 def test_delete_trial():
-    storage = Storage(ws.path)
+    storage = get_storage()
     assert storage.delete_trial(trial_id=1) is None
 
 
 # rollback_to_ready
 @t_base()
 def test_rollback_to_ready():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     assert storage.rollback_to_ready(trial_id=1) is None
 

--- a/tests/unit/storage_test/db/test_timestamp.py
+++ b/tests/unit/storage_test/db/test_timestamp.py
@@ -3,14 +3,14 @@ from sqlalchemy.exc import SQLAlchemyError
 from undecorated import undecorated
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import t_base, ws, init
+from tests.unit.storage_test.db.base import get_storage, init, t_base, ws
 
 # set_any_trial_start_time
 
 
 @t_base()
 def test_set_any_trial_start_time():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -30,7 +30,7 @@ def test_set_any_trial_start_time():
 
 @t_base()
 def test_set_any_trial_start_time_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -48,7 +48,7 @@ def test_set_any_trial_start_time_exception():
 # set_any_trial_end_time
 @t_base()
 def test_set_any_trial_end_time():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -73,7 +73,7 @@ def test_set_any_trial_end_time():
 # set_any_trial_end_time exception
 @t_base()
 def test_set_any_trial_end_time_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -96,7 +96,7 @@ def test_set_any_trial_end_time_exception():
 
 @t_base()
 def test_set_any_trial_end_time_assersion():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     end_time = "10:00"
@@ -114,7 +114,7 @@ def test_set_any_trial_end_time_assersion():
 
 @t_base()
 def test_get_any_trial_start_time():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -151,7 +151,7 @@ def test_get_any_trial_start_time():
 # get_any_trial_end_time
 @t_base()
 def test_get_any_trial_end_time():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -189,7 +189,7 @@ def test_get_any_trial_end_time():
 
 @t_base()
 def test_all_delete():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -215,7 +215,7 @@ def test_all_delete():
 # all_delete exception
 @t_base()
 def test_all_delete_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -240,7 +240,7 @@ def test_all_delete_exception():
 # delete_any_trial_timestamp
 @t_base()
 def test_delete_any_trial_timestamp():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"
@@ -314,7 +314,7 @@ def test_delete_any_trial_timestamp():
 # delete_any_trial_timestamp excedption
 @t_base()
 def test_delete_any_trial_timestamp_excedption():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     trial_id = 0
     start_time = "00:00"

--- a/tests/unit/storage_test/db/test_trial.py
+++ b/tests/unit/storage_test/db/test_trial.py
@@ -1,15 +1,15 @@
 import pytest
-from undecorated import undecorated
 from sqlalchemy.exc import SQLAlchemyError
+from undecorated import undecorated
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import t_base, ws, init
+from tests.unit.storage_test.db.base import get_storage, init, t_base, ws
 
 
 # set_any_trial_state
 @t_base()
 def test_set_any_trial_state():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = ["ready", "running", "finished"]
 
@@ -30,7 +30,7 @@ def test_set_any_trial_state():
 # set_any_trial_state exception
 @t_base()
 def test_set_any_trial_state_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     init()
     with pytest.raises(SQLAlchemyError):
@@ -46,7 +46,7 @@ def test_set_any_trial_state_exception():
 
 @t_base()
 def test_get_any_trial_state():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -73,7 +73,7 @@ def test_get_any_trial_state():
 # get_any_state_list
 @t_base()
 def test_get_any_state_list():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     assert storage.trial.get_any_state_list("ready") is None
 
@@ -103,7 +103,7 @@ def test_get_any_state_list():
 # all_delete
 @t_base()
 def test_all_delete():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -135,7 +135,7 @@ def test_all_delete():
 # all_delete exception
 @t_base()
 def test_all_delete_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -167,7 +167,7 @@ def test_all_delete_exception():
 # get_ready
 @t_base()
 def test_get_ready():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -193,7 +193,7 @@ def test_get_ready():
 # get_running
 @t_base()
 def test_get_running():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -219,7 +219,7 @@ def test_get_running():
 # get_finished
 @t_base()
 def test_get_finished():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -245,7 +245,7 @@ def test_get_finished():
 # get_all_trial_id
 @t_base()
 def test_get_all_trial_id():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     assert storage.trial.get_all_trial_id() is None
 
@@ -273,7 +273,7 @@ def test_get_all_trial_id():
 # delete_any_trial_state
 @t_base()
 def test_delete_any_trial_state():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",
@@ -313,7 +313,7 @@ def test_delete_any_trial_state():
 # delete_any_trial_state exception
 @t_base()
 def test_delete_any_trial_state_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
 
     states = [
         "ready",

--- a/tests/unit/storage_test/db/test_variable.py
+++ b/tests/unit/storage_test/db/test_variable.py
@@ -4,12 +4,12 @@ from sqlalchemy.exc import SQLAlchemyError
 from undecorated import undecorated
 
 from aiaccel.storage import Storage
-from tests.unit.storage_test.db.base import t_base, ws, init
+from tests.unit.storage_test.db.base import get_storage, init, t_base, ws
 
 
 @t_base()
 def test_serialize():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     # if labels[i] not in self.d.keys()
@@ -41,7 +41,7 @@ def test_serialize():
 
 @t_base()
 def test_set_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     init()
@@ -59,7 +59,7 @@ def test_set_exception():
 
 @t_base()
 def test_get():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     storage.variable.d['hoge'].set(trial_id=1, value=1.1)
@@ -69,14 +69,14 @@ def test_get():
 
 @t_base()
 def test_all_delete():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
     assert storage.variable.d['hoge'].all_delete() is None
 
 
 @t_base()
 def test_all_delete_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     init()
@@ -87,7 +87,7 @@ def test_all_delete_exception():
 
 @t_base()
 def test_delete_any_trial_variable():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     storage.variable.d['hoge'].set(trial_id=1, value=1.1)
@@ -127,7 +127,7 @@ def test_delete_any_trial_variable():
 
 @t_base()
 def test_delete_any_trial_variable_exception():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     storage.variable.d['hoge'].set(trial_id=1, value=1.1)
@@ -145,7 +145,7 @@ def test_delete_any_trial_variable_exception():
 
 @t_base()
 def test_delete():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     storage.variable.d['hoge'].set(trial_id=1, value=1.1)
@@ -170,7 +170,7 @@ def test_delete():
 
 @t_base()
 def test_delete_any_trial_variable():
-    storage = Storage(ws.path)
+    storage = get_storage()
     storage.variable.register(process_name='optimizer', labels=['hoge', 'foo', 'bar'])
 
     storage.variable.d['hoge'].set(trial_id=1, value=1.1)


### PR DESCRIPTION
I have changed the constructor argument of the Storage class from the workspace path to the database path to allow for intuitive access to database files located outside of the workspace. The goal is to create a script for analyzing multiple optimization results.
<hr>

Storageクラスのコンストラクタ引数をワークスペースのパスからデータベースのパスに変更しました。
この変更により、ワークスペース以外にあるデータベースファイルへのアクセスが直感的に行えるようになります。複数の最適化結果を解析するスクリプトを作成するような状況を想定しています．