### PR TITLE
Update hyperparameter data type string operations in aiaccel codebase

### DIFF
--- a/aiaccel/cli/set_result.py
+++ b/aiaccel/cli/set_result.py
@@ -5,18 +5,15 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from aiaccel.config import load_config
-from aiaccel.parameter import HyperParameterConfiguration
+from aiaccel.parameter import (
+    CategoricalParameter,
+    FloatParameter,
+    HyperParameterConfiguration,
+    IntParameter,
+    OrdinalParameter,
+)
+from aiaccel.util.data_type import str_or_float_or_int
 from aiaccel.util.filesystem import create_yaml
-
-
-def str_or_float_or_int(value: str | float | int) -> str | float | int:
-    try:
-        return int(value)
-    except ValueError:
-        try:
-            return float(value)
-        except ValueError:
-            return value
 
 
 def main() -> None:
@@ -44,14 +41,14 @@ def main() -> None:
         parameters_config = HyperParameterConfiguration(config.optimize.parameters)
 
         for p in parameters_config.get_parameter_list():
-            if p.type.lower() == "float":
+            if isinstance(p, FloatParameter):
                 parser.add_argument(f"--{p.name}", type=float)
-            elif p.type.lower() == "int":
+            elif isinstance(p, IntParameter):
                 parser.add_argument(f"--{p.name}", type=int)
-            elif p.type.lower() == "categorical":
-                parser.add_argument(f"--{p.name}", type=str)
-            elif p.type.lower() == "ordinal":
-                parser.add_argument(f"--{p.name}", type=float)
+            elif isinstance(p, CategoricalParameter):
+                parser.add_argument(f"--{p.name}", type=str_or_float_or_int)
+            elif isinstance(p, OrdinalParameter):
+                parser.add_argument(f"--{p.name}", type=str_or_float_or_int)
             else:
                 raise ValueError(f"Unknown parameter type: {p.type}")
         args = parser.parse_known_args()[0]
@@ -60,7 +57,7 @@ def main() -> None:
         for unknown_arg in unknown_args_list:
             if unknown_arg.startswith("--"):
                 name = unknown_arg.replace("--", "")
-                parser.add_argument(f"--{name}", type=float)
+                parser.add_argument(f"--{name}", type=str_or_float_or_int)
         args = parser.parse_known_args()[0]
 
     xs = vars(copy.deepcopy(args))

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -72,8 +72,8 @@ class ParameterConfig:
     upper: Union[float, int]
     # initial: Optional[Union[None, float, int, str, List[Union[float, int]]]]  # Unions of containers are not supported
     initial: Optional[Any]
-    choices: Optional[List[Union[None, float, int, str]]]
-    sequence: Optional[List[Union[None, float, int, str]]]
+    choices: Optional[List[str]]
+    sequence: Optional[List[float]]
     log: Optional[bool]
     base: Optional[int]
     step: Optional[Union[int, float]]

--- a/aiaccel/converted_parameter.py
+++ b/aiaccel/converted_parameter.py
@@ -100,7 +100,7 @@ class WeightOfChoice(ConvertedParameter):
         self.choice_index = choice_index
         self.original_name = self.name
         self.name = _make_weight_name(self.original_name, choice_index)
-        self.choices = param.choices if param.type.lower() == "categorical" else param.sequence
+        self.choices = list(param.choices if param.type.lower() == "categorical" else param.sequence)
         self.lower = 0.0
         self.upper = 1.0
         if isinstance(param.initial, Iterable) and not isinstance(param.initial, str):  # For Nelder-Mead
@@ -208,7 +208,8 @@ class ConvertedParameterConfiguration(HyperParameterConfiguration):
                         converted_params[converted_param.name] = converted_param
                     logger = getLogger("root.optimizer")
                     logger.warning(
-                        f"The choices of {param.name} is converted to {len(param.choices)} float parameters."
+                        f"The choices of {param.name} ({param.type}) is converted to "
+                        f"{len(param.choices)} float parameters."
                     )
                 else:
                     converted_params[param.name] = ConvertedCategoricalParameter(param, convert_choices=convert_choices)
@@ -219,7 +220,8 @@ class ConvertedParameterConfiguration(HyperParameterConfiguration):
                         converted_params[converted_param.name] = converted_param
                     logger = getLogger("root.optimizer")
                     logger.warning(
-                        f"The sequence of {param.name} is converted to {len(param.sequence)} float parameters."
+                        f"The sequence of {param.name} ({param.type}) is converted to "
+                        f"{len(param.sequence)} float parameters."
                     )
                 else:
                     converted_params[param.name] = ConvertedOrdinalParameter(param, convert_sequence=convert_sequence)
@@ -377,4 +379,8 @@ def _decode_weight_distribution(param: WeightOfChoice, weight_distribution: list
 
 
 def _make_structured_value(param: ConvertedParameter, value: Any) -> dict[str, Any]:
-    return {"parameter_name": param.name, "type": param.type, "value": value}
+    return {
+        "parameter_name": param.original_name if isinstance(param, WeightOfChoice) else param.name,
+        "type": param.type,
+        "value": value,
+    }

--- a/aiaccel/optimizer/_grid_point_generator.py
+++ b/aiaccel/optimizer/_grid_point_generator.py
@@ -9,7 +9,7 @@ from typing import Literal, Union
 import numpy as np
 from numpy.random import RandomState
 
-from aiaccel.parameter import HyperParameter
+from aiaccel.parameter import CategoricalParameter, FloatParameter, IntParameter, OrdinalParameter, Parameter
 
 GridValueType = Union[float, int, str]
 SamplingMethodType = Literal["IN_ORDER", "UNIFORM", "RANDOM", "DUPLICATABLE_RANDOM"]
@@ -21,17 +21,17 @@ class GridCondition(ABC):
     """An abstract class for grid condition container of a parameter.
 
     Args:
-        hyperparameter (HyperParameter): A hyperparameter object.
+        hyperparameter (Parameter): A hyperparameter object.
     """
 
-    def __init__(self, hyperparameter: HyperParameter) -> None:
+    def __init__(self, hyperparameter: Parameter) -> None:
         self._choices: list[GridValueType] = []
         self._num_choices: int = 0
         self._max_num_choices: int = sys.maxsize
         self.create_choices(hyperparameter)
 
     @abstractmethod
-    def create_choices(self, hyperparameter: HyperParameter) -> None:
+    def create_choices(self, hyperparameter: Parameter) -> None:
         ...
 
     def __contains__(self, value: object) -> bool:
@@ -84,11 +84,11 @@ class GridCondition(ABC):
         self._num_choices = num_choices
 
 
-def _is_there_zero_between_lower_and_upper(hyperparameter: HyperParameter) -> bool:
+def _is_there_zero_between_lower_and_upper(hyperparameter: Parameter) -> bool:
     return hyperparameter.lower * hyperparameter.upper <= 0
 
 
-def _validate_parameter_range(hyperparameter: HyperParameter) -> None:
+def _validate_parameter_range(hyperparameter: Parameter) -> None:
     if hyperparameter.log:
         if _is_there_zero_between_lower_and_upper(hyperparameter):
             raise ValueError("Zero cannot be included in the parameter range if log = true.")
@@ -98,10 +98,10 @@ class NumericGridCondition(GridCondition):
     """An abstract class for a grid condition container of a numeric parameter.
 
     Args:
-        hyperparameter (HyperParameter): A hyperparameter object.
+        hyperparameter (Parameter): A hyperparameter object.
     """
 
-    def __init__(self, hyperparameter: HyperParameter) -> None:
+    def __init__(self, hyperparameter: Parameter) -> None:
         _validate_parameter_range(hyperparameter)
         super().__init__(hyperparameter)
 
@@ -110,13 +110,13 @@ class FloatGridCondition(NumericGridCondition):
     """A grid condition container for a float parameter.
 
     Args:
-        hyperparameter (HyperParameter): A hyperparameter object.
+        hyperparameter (Parameter): A hyperparameter object.
     """
 
-    def __init__(self, hyperparameter: HyperParameter) -> None:
+    def __init__(self, hyperparameter: Parameter) -> None:
         super().__init__(hyperparameter)
 
-    def create_choices(self, hyperparameter: HyperParameter) -> None:
+    def create_choices(self, hyperparameter: Parameter) -> None:
         """Creates choices from specified hyperparameter.
 
         The number of choices is specified by a property `num_choices` if it is
@@ -125,7 +125,7 @@ class FloatGridCondition(NumericGridCondition):
         number of choices.
 
         Args:
-            hyperparameter (HyperParameter): A hyperparameter object.
+            hyperparameter (Parameter): A hyperparameter object.
         """
         start = hyperparameter.lower
         stop = hyperparameter.upper
@@ -168,13 +168,13 @@ class IntGridCondition(NumericGridCondition):
     """A grid condition container for an int parameter.
 
     Args:
-        hyperparameter (HyperParameter): A hyperparameter object.
+        hyperparameter (Parameter): A hyperparameter object.
     """
 
-    def __init__(self, hyperparameter: HyperParameter) -> None:
+    def __init__(self, hyperparameter: Parameter) -> None:
         super().__init__(hyperparameter)
 
-    def create_choices(self, hyperparameter: HyperParameter) -> None:
+    def create_choices(self, hyperparameter: Parameter) -> None:
         """Creates choices from specified hyperparameter.
 
         The number of choices is specified by a property `num_choices` if it is
@@ -183,7 +183,7 @@ class IntGridCondition(NumericGridCondition):
         number of choices.
 
         Args:
-            hyperparameter (HyperParameter): A hyperparameter object.
+            hyperparameter (Parameter): A hyperparameter object.
 
         Raises:
             ValueError: Causes when lower and upper values of hyperparameter
@@ -231,56 +231,58 @@ class CategoricalGridCondition(GridCondition):
     """A grid condition container for a categorical parameter.
 
     Args:
-        hyperparameter (HyperParameter): A hyperparameter object.
+        hyperparameter (Parameter): A hyperparameter object.
     """
 
-    def __init__(self, hyperparameter: HyperParameter) -> None:
+    def __init__(self, hyperparameter: Parameter) -> None:
         super().__init__(hyperparameter)
 
-    def create_choices(self, hyperparameter: HyperParameter) -> None:
+    def create_choices(self, hyperparameter: Parameter) -> None:
         """Creates choices from specified hyperparameter.
 
         The choices are equivalent to `hyperparameter.sequence`.
 
         Args:
-            hyperparameter (HyperParameter): A hyperparameter object.
+            hyperparameter (Parameter): A hyperparameter object.
         """
-        self.choices = hyperparameter.choices
-        self.num_choices = len(self.choices)
-        self._max_num_choices = self.num_choices
+        if isinstance(hyperparameter, CategoricalParameter):
+            self.choices = hyperparameter.choices
+            self.num_choices = len(self.choices)
+            self._max_num_choices = self.num_choices
 
 
 class OrdinalGridCondition(GridCondition):
     """A grid condition container for an ordinal parameter.
 
     Args:
-        hyperparameter (HyperParameter): A hyperparameter object.
+        hyperparameter (Parameter): A hyperparameter object.
     """
 
-    def __init__(self, hyperparameter: HyperParameter) -> None:
+    def __init__(self, hyperparameter: Parameter) -> None:
         super().__init__(hyperparameter)
 
-    def create_choices(self, hyperparameter: HyperParameter) -> None:
+    def create_choices(self, hyperparameter: Parameter) -> None:
         """Creates choices from specified hyperparameter.
 
         The choices are equivalent to `hyperparameter.choices`.
 
         Args:
-            hyperparameter (HyperParameter): A hyperparameter object.
+            hyperparameter (Parameter): A hyperparameter object.
         """
-        self.choices = hyperparameter.sequence
-        self.num_choices = len(self.choices)
-        self._max_num_choices = self.num_choices
+        if isinstance(hyperparameter, OrdinalParameter):
+            self.choices = hyperparameter.sequence
+            self.num_choices = len(self.choices)
+            self._max_num_choices = self.num_choices
 
 
-def _create_grid_condition(hyperparameter: HyperParameter) -> GridCondition:
-    if hyperparameter.type == "FLOAT":
+def _create_grid_condition(hyperparameter: Parameter) -> GridCondition:
+    if isinstance(hyperparameter, FloatParameter):
         return FloatGridCondition(hyperparameter)
-    elif hyperparameter.type == "INT":
+    elif isinstance(hyperparameter, IntParameter):
         return IntGridCondition(hyperparameter)
-    elif hyperparameter.type == "CATEGORICAL":
+    elif isinstance(hyperparameter, CategoricalParameter):
         return CategoricalGridCondition(hyperparameter)
-    elif hyperparameter.type == "ORDINAL":
+    elif isinstance(hyperparameter, OrdinalParameter):
         return OrdinalGridCondition(hyperparameter)
     else:
         raise TypeError(f'Specified parameter type "{hyperparameter.type}" of "{hyperparameter.name}" is invalid.')
@@ -291,11 +293,11 @@ class GridConditionCollection:
 
     Args:
         num_trials (int): The number of trials.
-        hyperparameters (list[HyperParameter]): A list of Hyperparameter
+        hyperparameters (list[Parameter]): A list of Hyperparameter
             objects.
     """
 
-    def __init__(self, num_trials: int, hyperparameters: list[HyperParameter]) -> None:
+    def __init__(self, num_trials: int, hyperparameters: list[Parameter]) -> None:
         self._num_trials = num_trials
         self._conditions: list[GridCondition] = []
         self._least_space_size = 1
@@ -316,7 +318,7 @@ class GridConditionCollection:
     def __len__(self) -> int:
         return len(self._conditions)
 
-    def _register_grid_conditions(self, hyperparameters: list[HyperParameter]) -> None:
+    def _register_grid_conditions(self, hyperparameters: list[Parameter]) -> None:
         if hyperparameters:
             hyperparameter = hyperparameters.pop(0)
             grid_condition = _create_grid_condition(hyperparameter)
@@ -363,7 +365,7 @@ class GridPointGenerator:
     """Generator of grid points.
 
     Args:
-        hyperparameters (list[HyperParameter]): A list of HyperParameter
+        hyperparameters (list[Parameter]): A list of Parameter
             object.
         trial_number (int): The number of trials.
         sampling_method (SamplingMethod, optional): How to sample the grid
@@ -403,7 +405,7 @@ class GridPointGenerator:
     def __init__(
         self,
         num_trials: int,
-        hyperparameters: list[HyperParameter],
+        hyperparameters: list[Parameter],
         sampling_method: SamplingMethodType = "IN_ORDER",
         rng: RandomState | None = None,
         accept_small_trial_number: bool = False,

--- a/aiaccel/optimizer/abstract_optimizer.py
+++ b/aiaccel/optimizer/abstract_optimizer.py
@@ -8,7 +8,7 @@ from omegaconf.dictconfig import DictConfig
 
 from aiaccel.config import is_multi_objective
 from aiaccel.module import AbstractModule
-from aiaccel.parameter import HyperParameterConfiguration
+from aiaccel.parameter import HyperParameterConfiguration, is_categorical, is_ordinal, is_uniform_float, is_uniform_int
 from aiaccel.util import TrialId, str_to_logging_level
 
 
@@ -267,13 +267,12 @@ class AbstractOptimizer(AbstractModule):
                     _param["type"] = str(type(None))
 
             try:
-                if param_type.lower() == "categorical" or param_type.lower() == "ordinal":
+                if is_categorical(param_type) or is_ordinal(param_type):
                     casted_params.append(_param)
                     continue
-
-                if param_type.lower() == "float":
+                if is_uniform_float(param_type):
                     _param["value"] = float(param_value)
-                if param_type.lower() == "int":
+                if is_uniform_int(param_type):
                     _param["value"] = int(param_value)
                 casted_params.append(_param)
 

--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -8,7 +8,7 @@ from typing import Any
 from omegaconf.dictconfig import DictConfig
 
 from aiaccel.optimizer import AbstractOptimizer
-from aiaccel.parameter import HyperParameter
+from aiaccel.parameter import CategoricalParameter, FloatParameter, IntParameter, OrdinalParameter, Parameter
 
 
 def get_grid_options(parameter_name: str, config: DictConfig) -> tuple[Any, bool, Any]:
@@ -51,11 +51,11 @@ def get_grid_options(parameter_name: str, config: DictConfig) -> tuple[Any, bool
     raise KeyError(f"Invalid parameter name: {parameter_name}")
 
 
-def generate_grid_points(p: HyperParameter, config: DictConfig) -> dict[str, Any]:
+def generate_grid_points(p: Parameter, config: DictConfig) -> dict[str, Any]:
     """Make a list of all parameters for this grid.
 
     Args:
-        p (HyperParameter): A hyper parameter object.
+        p (Parameter): A hyper parameter object.
         config (DictConfig): A configuration object.
 
     Returns:
@@ -67,7 +67,7 @@ def generate_grid_points(p: HyperParameter, config: DictConfig) -> dict[str, Any
     """
     new_param = {"parameter_name": p.name, "type": p.type}
 
-    if p.type.lower() in ["int", "float"]:
+    if isinstance(p, FloatParameter) or isinstance(p, IntParameter):
         base, log, step = get_grid_options(p.name, config)
         lower = p.lower
         upper = p.upper
@@ -84,13 +84,13 @@ def generate_grid_points(p: HyperParameter, config: DictConfig) -> dict[str, Any
         else:
             n = int((upper - lower) / step) + 1
             new_param["parameters"] = [lower + i * step for i in range(0, n)]
-        if p.type.lower() == "int":
+        if isinstance(p, IntParameter):
             new_param["parameters"] = [int(i) for i in new_param["parameters"]]
 
-    elif p.type.lower() == "categorical":
+    elif isinstance(p, CategoricalParameter):
         new_param["parameters"] = p.choices
 
-    elif p.type.lower() == "ordinal":
+    elif isinstance(p, OrdinalParameter):
         new_param["parameters"] = p.sequence
 
     else:

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -6,9 +6,9 @@ from typing import Any
 from omegaconf.dictconfig import DictConfig
 
 from aiaccel.config import is_multi_objective
-from aiaccel.converted_parameter import ConvertedParameterConfiguration
-from aiaccel.optimizer._nelder_mead import NelderMead
-from aiaccel.optimizer.abstract_optimizer import AbstractOptimizer
+from aiaccel.converted_parameter import ConvertedFloatParameter, ConvertedIntParameter, ConvertedParameterConfiguration
+from aiaccel.optimizer import AbstractOptimizer, NelderMead
+from aiaccel.parameter import FloatParameter, IntParameter, OrdinalParameter
 
 
 class NelderMeadOptimizer(AbstractOptimizer):

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -6,9 +6,8 @@ from typing import Any
 from omegaconf.dictconfig import DictConfig
 
 from aiaccel.config import is_multi_objective
-from aiaccel.converted_parameter import ConvertedFloatParameter, ConvertedIntParameter, ConvertedParameterConfiguration
+from aiaccel.converted_parameter import ConvertedParameterConfiguration
 from aiaccel.optimizer import AbstractOptimizer, NelderMead
-from aiaccel.parameter import FloatParameter, IntParameter, OrdinalParameter
 
 
 class NelderMeadOptimizer(AbstractOptimizer):

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -26,11 +26,11 @@ class SobolOptimizer(AbstractOptimizer):
 
     def __init__(self, config: DictConfig) -> None:
         super().__init__(config)
+        self.params: ConvertedParameterConfiguration = ConvertedParameterConfiguration(self.params)
         self.num_generated_params = 0
         self.sampler = qmc.Sobol(
             d=len(self.params.get_parameter_list()), scramble=self.config.optimize.sobol_scramble, seed=self._rng
         )
-        self.params: ConvertedParameterConfiguration = ConvertedParameterConfiguration(self.params)
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -9,7 +9,13 @@ from omegaconf.dictconfig import DictConfig
 from optuna.storages._rdb import models
 
 from aiaccel.optimizer import AbstractOptimizer
-from aiaccel.parameter import HyperParameterConfiguration
+from aiaccel.parameter import (
+    CategoricalParameter,
+    FloatParameter,
+    HyperParameterConfiguration,
+    IntParameter,
+    OrdinalParameter,
+)
 
 
 class TPESamplerWrapper(optuna.samplers.TPESampler):
@@ -226,7 +232,7 @@ def create_distributions(
             parameter configuration object.
 
     Raises:
-        ValueError: Occurs when parameter type is other than 'float', 'int',
+        ValueError: Occurs when parameter type is other than 'uniform_float',uniform_int',
             'categorical', or 'ordinal'.
 
     Returns:
@@ -235,16 +241,16 @@ def create_distributions(
     distributions: dict[str, Any] = {}
 
     for p in parameters.get_parameter_list():
-        if p.type.lower() == "float":
+        if isinstance(p, FloatParameter):
             distributions[p.name] = optuna.distributions.FloatDistribution(p.lower, p.upper, log=p.log)
 
-        elif p.type.lower() == "int":
+        elif isinstance(p, IntParameter):
             distributions[p.name] = optuna.distributions.IntDistribution(p.lower, p.upper, log=p.log)
 
-        elif p.type.lower() == "categorical":
+        elif isinstance(p, CategoricalParameter):
             distributions[p.name] = optuna.distributions.CategoricalDistribution(p.choices)
 
-        elif p.type.lower() == "ordinal":
+        elif isinstance(p, OrdinalParameter):
             distributions[p.name] = optuna.distributions.CategoricalDistribution(p.sequence)
 
         else:

--- a/aiaccel/util/__init__.py
+++ b/aiaccel/util/__init__.py
@@ -1,3 +1,4 @@
+from aiaccel.parameter import CategoricalParameter, FloatParameter, IntParameter, OrdinalParameter, Parameter
 from aiaccel.util.buffer import Buffer
 from aiaccel.util.cast import cast_y
 from aiaccel.util.easy_visualizer import EasyVisualizer
@@ -63,4 +64,9 @@ __all__ = [
     "retry",
     "str_to_logging_level",
     "subprocess_ps",
+    "CategoricalParameter",
+    "FloatParameter",
+    "IntParameter",
+    "OrdinalParameter",
+    "Parameter",
 ]

--- a/aiaccel/util/aiaccel.py
+++ b/aiaccel/util/aiaccel.py
@@ -8,8 +8,15 @@ from pathlib import Path
 from typing import Any
 
 from aiaccel.config import load_config
-from aiaccel.parameter import HyperParameterConfiguration
+from aiaccel.parameter import (
+    CategoricalParameter,
+    FloatParameter,
+    HyperParameterConfiguration,
+    IntParameter,
+    OrdinalParameter,
+)
 from aiaccel.util import cast_y, get_time_now
+from aiaccel.util.data_type import str_or_float_or_int
 
 
 class CommandLineArgs:
@@ -30,14 +37,14 @@ class CommandLineArgs:
             self.parameters_config = HyperParameterConfiguration(self.config.optimize.parameters)
 
             for p in self.parameters_config.get_parameter_list():
-                if p.type.lower() == "float":
+                if isinstance(p, FloatParameter):
                     self.parser.add_argument(f"--{p.name}", type=float)
-                elif p.type.lower() == "int":
+                elif isinstance(p, IntParameter):
                     self.parser.add_argument(f"--{p.name}", type=int)
-                elif p.type.lower() == "categorical":
-                    self.parser.add_argument(f"--{p.name}", type=str)
-                elif p.type.lower() == "ordinal":
-                    self.parser.add_argument(f"--{p.name}", type=float)
+                elif isinstance(p, CategoricalParameter):
+                    self.parser.add_argument(f"--{p.name}", type=str_or_float_or_int)
+                elif isinstance(p, OrdinalParameter):
+                    self.parser.add_argument(f"--{p.name}", type=str_or_float_or_int)
                 else:
                     raise ValueError(f"Unknown parameter type: {p.type}")
             self.args = self.parser.parse_known_args()[0]
@@ -46,7 +53,7 @@ class CommandLineArgs:
             for unknown_arg in unknown_args_list:
                 if unknown_arg.startswith("--"):
                     name = unknown_arg.replace("--", "")
-                    self.parser.add_argument(f"--{name}", type=float)
+                    self.parser.add_argument(f"--{name}", type=str_or_float_or_int)
             self.args = self.parser.parse_known_args()[0]
 
     def get_xs_from_args(self) -> dict[str, Any]:

--- a/aiaccel/util/data_type.py
+++ b/aiaccel/util/data_type.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Union
+
+
+def str_or_float_or_int(value: str | float | int) -> Union[str, float, int]:
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+def float_or_int(value: float | int) -> Union[float, int]:
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError as e:
+            raise e

--- a/tests/unit/abci_test/test_abci_batch.py
+++ b/tests/unit/abci_test/test_abci_batch.py
@@ -50,12 +50,12 @@ class TestCreateAbciBatchFile(BaseTest):
             'parameters': [
                 {
                     'parameter_name': 'x1',
-                    'type': 'FLOAT',
+                    'type': 'uniform_float',
                     'value': -4.716525234779937
                 },
                 {
                     'parameter_name': 'x2',
-                    'type': 'FLOAT',
+                    'type': 'uniform_float',
                     'value': 123456
                 }
             ],

--- a/tests/unit/cli_test/test_report.py
+++ b/tests/unit/cli_test/test_report.py
@@ -1,12 +1,10 @@
 import pathlib
-
 from unittest.mock import patch
 
+from aiaccel.cli import CsvWriter
 from aiaccel.cli.report import main
 from aiaccel.config import load_config
-from aiaccel.cli import CsvWriter
 from aiaccel.workspace import Workspace
-
 
 ws = Workspace("test_work")
 config_path = pathlib.Path('tests/test_data/config.json')

--- a/tests/unit/master_test/test_abstract_master.py
+++ b/tests/unit/master_test/test_abstract_master.py
@@ -6,7 +6,6 @@ import time
 from aiaccel.common import goal_maximize
 from aiaccel.master import AbstractMaster
 from aiaccel.util import get_time_now_object
-
 from tests.base_test import BaseTest
 
 
@@ -83,7 +82,7 @@ class TestAbstractMaster(BaseTest):
                     trial_id=i,
                     param_name=f"x{j}",
                     param_value=0.0,
-                    param_type='flaot'
+                    param_type='uniform_float'
                 )
         assert master.post_process() is None
 

--- a/tests/unit/optimizer_test/test_abstract_optimizer.py
+++ b/tests/unit/optimizer_test/test_abstract_optimizer.py
@@ -46,8 +46,8 @@ class TestAbstractOptimizer(BaseTest):
 
     def test_register_new_parameters(self):
         params = [
-            {'parameter_name': 'x1', 'type': 'FLOAT', 'value': 0.1},
-            {'parameter_name': 'x2', 'type': 'FLOAT', 'value': 0.1}
+            {'parameter_name': 'x1', 'type': 'uniform_float', 'value': 0.1},
+            {'parameter_name': 'x2', 'type': 'uniform_float', 'value': 0.1}
         ]
 
         assert self.optimizer.register_new_parameters(params) is None
@@ -57,14 +57,14 @@ class TestAbstractOptimizer(BaseTest):
             assert self.optimizer.generate_initial_parameter() == []
 
         p = [
-            {'name': "x1", 'type': 'FLOAT', 'value': 1.0},
-            {'name': "x2", 'type': 'FLOAT', 'value': 2.0},
+            {'name': "x1", 'type': 'uniform_float', 'value': 1.0},
+            {'name': "x2", 'type': 'uniform_float', 'value': 2.0},
         ]
 
         with patch.object(self.optimizer.params, 'sample', return_value=p):
             assert self.optimizer.generate_initial_parameter() == [
-                {'parameter_name': 'x1', 'type': 'FLOAT', 'value': 1.0},
-                {'parameter_name': 'x2', 'type': 'FLOAT', 'value': 2.0}
+                {'parameter_name': 'x1', 'type': 'uniform_float', 'value': 1.0},
+                {'parameter_name': 'x2', 'type': 'uniform_float', 'value': 2.0}
             ]
 
     def test_generate_parameter(self) -> None:
@@ -96,10 +96,10 @@ class TestAbstractOptimizer(BaseTest):
         assert self.optimizer.post_process() is None
 
     def test_inner_loop_main_process(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        initial = [{'parameter_name': 'x1', 'type': 'FLOAT', 'value': 0.1},
-                   {'parameter_name': 'x2', 'type': 'FLOAT', 'value': 0.1}]
-        param = [{'parameter_name': 'x1', 'type': 'FLOAT', 'value': 0.2},
-                 {'parameter_name': 'x2', 'type': 'FLOAT', 'value': 0.2}]
+        initial = [{'parameter_name': 'x1', 'type': 'uniform_float', 'value': 0.1},
+                   {'parameter_name': 'x2', 'type': 'uniform_float', 'value': 0.1}]
+        param = [{'parameter_name': 'x1', 'type': 'uniform_float', 'value': 0.2},
+                 {'parameter_name': 'x2', 'type': 'uniform_float', 'value': 0.2}]
 
         with monkeypatch.context() as m:
             m.setattr(self.optimizer, 'generate_initial_parameter', lambda: initial)
@@ -133,26 +133,26 @@ class TestAbstractOptimizer(BaseTest):
             assert self.optimizer.inner_loop_main_process() is True
 
     def test_cast(self):
-        org_params = [{'parameter_name': 'x1', 'type': 'INT', 'value': 0.1},
-                      {'parameter_name': 'x2', 'type': 'INT', 'value': 1.5}]
+        org_params = [{'parameter_name': 'x1', 'type': 'uniform_int', 'value': 0.1},
+                      {'parameter_name': 'x2', 'type': 'uniform_int', 'value': 1.5}]
         new_params = self.optimizer.cast(org_params)
         assert new_params[0]["value"] == 0
         assert new_params[1]["value"] == 1
 
-        org_params = [{'parameter_name': 'x1', 'type': 'FLOAT', 'value': 0.1},
-                      {'parameter_name': 'x2', 'type': 'FLOAT', 'value': 1.5}]
+        org_params = [{'parameter_name': 'x1', 'type': 'uniform_float', 'value': 0.1},
+                      {'parameter_name': 'x2', 'type': 'uniform_float', 'value': 1.5}]
         new_params = self.optimizer.cast(org_params)
         assert new_params[0]["value"] == 0.1
         assert new_params[1]["value"] == 1.5
 
-        org_params = [{'parameter_name': 'x1', 'type': 'CATEGORICAL', 'value': 'a'},
-                      {'parameter_name': 'x2', 'type': 'CATEGORICAL', 'value': 'b'}]
+        org_params = [{'parameter_name': 'x1', 'type': 'categorical', 'value': 'a'},
+                      {'parameter_name': 'x2', 'type': 'categorical', 'value': 'b'}]
         new_params = self.optimizer.cast(org_params)
         assert new_params[0]["value"] == 'a'
         assert new_params[1]["value"] == 'b'
 
-        org_params = [{'parameter_name': 'x1', 'type': 'ORDINAL', 'value': [1, 2, 3]},
-                      {'parameter_name': 'x2', 'type': 'ORDINAL', 'value': [4, 5, 6]}]
+        org_params = [{'parameter_name': 'x1', 'type': 'ordinal', 'value': [1, 2, 3]},
+                      {'parameter_name': 'x2', 'type': 'ordinal', 'value': [4, 5, 6]}]
         new_params = self.optimizer.cast(org_params)
         assert new_params[0]["value"] == [1, 2, 3]
         assert new_params[1]["value"] == [4, 5, 6]

--- a/tests/unit/optimizer_test/test_grid_optimizer.py
+++ b/tests/unit/optimizer_test/test_grid_optimizer.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 
 import pytest
 from omegaconf.errors import MissingMandatoryValue
 
 from aiaccel.config import load_config
-from aiaccel.parameter import HyperParameter, HyperParameterConfiguration
-from aiaccel.optimizer import GridOptimizer
-from aiaccel.optimizer import generate_grid_points
-from aiaccel.optimizer import get_grid_options
+from aiaccel.optimizer import GridOptimizer, generate_grid_points, get_grid_options
+from aiaccel.parameter import HyperParameterConfiguration, Parameter
 from tests.base_test import BaseTest
 
 
@@ -63,7 +60,7 @@ def test_generate_grid_points(grid_load_test_config):
     for p in params.get_parameter_list():
         generate_grid_points(p, config)
 
-    int_p = HyperParameter(
+    int_p = Parameter(
         {
             'name': 'x4',
             'type': 'uniform_int',
@@ -77,7 +74,7 @@ def test_generate_grid_points(grid_load_test_config):
 
     assert generate_grid_points(int_p, config)
 
-    cat_p = HyperParameter(
+    cat_p = Parameter(
         {
             'name': 'x3',
             'type': 'categorical',
@@ -102,7 +99,7 @@ def test_generate_grid_points(grid_load_test_config):
     except TypeError:
         assert True
 
-    cat_p = HyperParameter(
+    cat_p = Parameter(
         {
             'name': 'x3',
             'type': 'ordinal',

--- a/tests/unit/optimizer_test/test_grid_point_generator.py
+++ b/tests/unit/optimizer_test/test_grid_point_generator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Literal
 
@@ -9,28 +8,26 @@ import numpy as np
 import pytest
 from numpy.random import RandomState
 
-from aiaccel.config import Config
-from aiaccel.optimizer._grid_point_generator import CategoricalGridCondition
-from aiaccel.optimizer._grid_point_generator import FloatGridCondition
-from aiaccel.optimizer._grid_point_generator import GridCondition
-from aiaccel.optimizer._grid_point_generator import GridConditionCollection
-from aiaccel.optimizer._grid_point_generator import GridPointGenerator
-from aiaccel.optimizer._grid_point_generator import IntGridCondition
-from aiaccel.optimizer._grid_point_generator import NumericGridCondition
-from aiaccel.optimizer._grid_point_generator import OrdinalGridCondition
-from aiaccel.optimizer._grid_point_generator import _cast_start_to_integer
-from aiaccel.optimizer._grid_point_generator import _cast_stop_to_integer
-from aiaccel.optimizer._grid_point_generator import _create_grid_condition
-from aiaccel.optimizer._grid_point_generator import _is_there_zero_between_lower_and_upper
-from aiaccel.optimizer._grid_point_generator import _validate_parameter_range
-from aiaccel.optimizer._grid_point_generator import GridValueType
-from aiaccel.optimizer._grid_point_generator import NumericType
-from aiaccel.parameter import HyperParameter
-from aiaccel.parameter import load_parameter
-
+from aiaccel.config import Config, load_config
+from aiaccel.optimizer._grid_point_generator import (
+    CategoricalGridCondition,
+    FloatGridCondition,
+    GridCondition,
+    GridConditionCollection,
+    GridPointGenerator,
+    GridValueType,
+    IntGridCondition,
+    NumericGridCondition,
+    NumericType,
+    OrdinalGridCondition,
+    _cast_start_to_integer,
+    _cast_stop_to_integer,
+    _create_grid_condition,
+    _is_there_zero_between_lower_and_upper,
+    _validate_parameter_range,
+)
+from aiaccel.parameter import Parameter, load_parameter
 from tests.base_test import BaseTest
-from aiaccel.parameter import HyperParameterConfiguration
-from aiaccel.config import load_config
 
 
 class TestGridCondition:
@@ -38,10 +35,10 @@ class TestGridCondition:
     def setup(self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
         self.choices = [0, 1, 2]
         self.num_choices = len(self.choices)
-        self.hyperparameter = HyperParameter(
+        self.hyperparameter = Parameter(
             {
                 'name': 'test',
-                'type': "FLOAT",
+                'type': "uniform_float",
                 'lower': None,
                 'upper': None,
                 'log': None,
@@ -141,10 +138,10 @@ argvalues_is_there_zero_between_lower_and_upper = [
     argvalues_is_there_zero_between_lower_and_upper,
 )
 def is_there_zero_between_lower_and_upper(lower, upper, expect) -> None:
-    hyperparameter = HyperParameter(
+    hyperparameter = Parameter(
         {
             "name": "test",
-            "type": "FLOAT",
+            "type": 'uniform_float',
             "lower": lower,
             "upper": upper,
             "log": None,
@@ -157,10 +154,10 @@ def is_there_zero_between_lower_and_upper(lower, upper, expect) -> None:
 
 
 def test_validate_parameter_range(monkeypatch: pytest.MonkeyPatch) -> None:
-    hyperparameter = HyperParameter(
+    hyperparameter = Parameter(
         {
             "name": "test",
-            "type": "FLOAT",
+            "type": 'uniform_float',
             "lower": 1.0,
             "upper": 10.0,
             "log": None,
@@ -185,10 +182,10 @@ def test_validate_parameter_range(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestNumericGridCondition:
     def test_init(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        hyperparameter = HyperParameter(
+        hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "FLOAT",
+                "type": 'uniform_float',
                 "lower": 1.0,
                 "upper": 10.0,
                 "log": None,
@@ -222,10 +219,10 @@ argvalues_float_grid_condition_create_choices = [
 class TestFloatGridCondition:
     @pytest.fixture(autouse=True)
     def setup(self) -> Generator[None, None, None]:
-        self.hyperparameter = HyperParameter(
+        self.hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "FLOAT",
+                "type": 'uniform_float',
                 "lower": 1.0,
                 "upper": 10.0,
                 "log": None,
@@ -257,10 +254,10 @@ class TestFloatGridCondition:
         num_numeric_choices: int | None,
         choices: list[float]
     ) -> None:
-        hyperparameter = HyperParameter(
+        hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "FLOAT",
+                "type": 'uniform_float',
                 "lower": 1.0,
                 "upper": 10.0,
                 "log": log,
@@ -275,10 +272,10 @@ class TestFloatGridCondition:
             assert grid_condition.choices == choices
 
     def test_num_choices(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        hyperparameter = HyperParameter(
+        hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "FLOAT",
+                "type": 'uniform_float',
                 "lower": 1.0,
                 "upper": 10.0,
                 "log": False,
@@ -336,10 +333,10 @@ class TestIntGridCondition:
     def setup(self) -> Generator[None, None, None]:
         self.choices = [0, 1, 2]
         self.num_choices = len(self.choices)
-        self.hyperparameter = HyperParameter(
+        self.hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "INT",
+                "type": 'uniform_int',
                 "lower": 1.0,
                 "upper": 10.0,
                 "log": None,
@@ -377,10 +374,10 @@ class TestIntGridCondition:
         num_numeric_choices: int | None,
         choices: list[float]
     ) -> None:
-        hyperparameter = HyperParameter(
+        hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "INT",
+                "type": 'uniform_int',
                 "lower": lower,
                 "upper": upper,
                 "log": log,
@@ -425,10 +422,10 @@ class TestCategoricalGridCondition:
     def setup(self) -> Generator[None, None, None]:
         self.choices = [0, 1, 2]
         self.num_choices = len(self.choices)
-        self.hyperparameter = HyperParameter(
+        self.hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "CATEGORICAL",
+                "type": 'categorical',
                 "choices": self.choices,
             }
         )
@@ -455,10 +452,10 @@ class TestOrdinalGridCondition:
     def setup(self) -> Generator[None, None, None]:
         self.choices = [0, 1, 2]
         self.num_choices = len(self.choices)
-        self.hyperparameter = HyperParameter(
+        self.hyperparameter = Parameter(
             {
                 "name": "test",
-                "type": "ORDINAL",
+                "type": 'ordinal',
                 "sequence": self.choices,
             }
         )
@@ -481,28 +478,29 @@ class TestOrdinalGridCondition:
 
 
 def test_create_grid_condition(monkeypatch: pytest.MonkeyPatch) -> None:
-    hyperparameter = HyperParameter(
-        {
-            "name": "test",
-            "type": "FLOAT"
-        }
-    )
+    parameter_info = {"name": "test", "type": 'uniform_float'}
+    hyperparameter = Parameter(parameter_info)
     with monkeypatch.context() as m:
         m.setattr(GridCondition, "__init__", lambda *_: None)
-        hyperparameter.type = "FLOAT"
+        hyperparameter.type = 'uniform_float'
         grid_condition = _create_grid_condition(hyperparameter)
         assert isinstance(grid_condition, FloatGridCondition)
-        hyperparameter.type = "INT"
+        parameter_info["type"] = "uniform_int"
+        hyperparameter = Parameter(parameter_info)
         grid_condition = _create_grid_condition(hyperparameter)
+        print(grid_condition)
         assert isinstance(grid_condition, IntGridCondition)
-        hyperparameter.type = "CATEGORICAL"
+        parameter_info["type"] = "categorical"
+        hyperparameter = Parameter(parameter_info)
         grid_condition = _create_grid_condition(hyperparameter)
         assert isinstance(grid_condition, CategoricalGridCondition)
-        hyperparameter.type = "ORDINAL"
+        parameter_info["type"] = "ordinal"
+        hyperparameter = Parameter(parameter_info)
         grid_condition = _create_grid_condition(hyperparameter)
         assert isinstance(grid_condition, OrdinalGridCondition)
         with pytest.raises(TypeError):
-            hyperparameter.type = "INVALID"
+            parameter_info["type"] = "INVALID"
+            hyperparameter = Parameter(parameter_info)
             _ = _create_grid_condition(hyperparameter)
 
 
@@ -510,12 +508,12 @@ argnames_grid_condition_collection_register = (
     'num_trials, parameter_type, lower, upper, num_numeric_choices, log, choices, sequence, expect'
 )
 argvalues_grid_condition_collection_register = [
-    (10, 'FLOAT', 0.0, 1.0, 10, False, None, None, list(map(float, np.linspace(0.0, 1.0, 10)))),
-    (10, 'FLOAT', 0.0, 1.0, None, False, None, None, list(map(float, np.linspace(0.0, 1.0, 10)))),
-    (10, 'INT', 0, 10, 10, False, None, None, list(set(np.linspace(0, 10, 10, dtype=int)))),
-    (10, 'INT', 0, 10, None, False, None, None, list(set(np.linspace(0, 10, 10, dtype=int)))),
-    (10, 'CATEGORICAL', None, None, None, None, ['a', 'b'], None, ['a', 'b']),
-    (10, 'ORDINAL', None, None, None, None, None, [0, 1], [0, 1])
+    (10, 'uniform_float', 0.0, 1.0, 10, False, None, None, list(map(float, np.linspace(0.0, 1.0, 10)))),
+    (10, 'uniform_float', 0.0, 1.0, None, False, None, None, list(map(float, np.linspace(0.0, 1.0, 10)))),
+    (10, 'uniform_int', 0, 10, 10, False, None, None, list(set(np.linspace(0, 10, 10, dtype=int)))),
+    (10, 'uniform_int', 0, 10, None, False, None, None, list(set(np.linspace(0, 10, 10, dtype=int)))),
+    (10, 'categorical', None, None, None, None, ['a', 'b'], None, ['a', 'b']),
+    (10, 'ordinal', None, None, None, None, None, [0, 1], [0, 1])
 ]
 
 
@@ -523,10 +521,10 @@ class TestGridConditionCollection:
     @ pytest.fixture(autouse=True)
     def setup_hyperparameters(self, request: pytest.FixtureRequest) -> Generator[None, None, None]:
         self.hyperparameters = [
-            HyperParameter(
+            Parameter(
                 {
                     'name': 'test',
-                    'type': 'INT',
+                    'type': 'uniform_int',
                     'lower': 0.0,
                     'upper': 1.0,
                     'log': False,
@@ -577,7 +575,7 @@ class TestGridConditionCollection:
     def test_register_grid_conditions(
         self,
         num_trials: int,
-        parameter_type: Literal['FLOAT', 'INT', 'CATEGORICAL', 'ORDINAL'],
+        parameter_type: Literal['uniform_float', 'uniform_int', 'categorical', 'ordinal'],
         lower: float | int | None,
         upper: float | int | None,
         num_numeric_choices: int | None,
@@ -587,7 +585,7 @@ class TestGridConditionCollection:
         expect: list[GridValueType]
     ) -> None:
         hyperparameters = [
-            HyperParameter(
+            Parameter(
                 {
                     'name': 'test',
                     'type': parameter_type,
@@ -606,10 +604,10 @@ class TestGridConditionCollection:
     def test_get_grid_conditions_with_empty_choices(self, monkeypatch: pytest.MonkeyPatch) -> None:
         conditions = [
             FloatGridCondition(
-                HyperParameter(
+                Parameter(
                     {
                         "name": "x1",
-                        "type": "FLOAT",
+                        "type": "uniform_float",
                         "lower": 0.0,
                         "upper": 1.0,
                         "log": False
@@ -617,10 +615,10 @@ class TestGridConditionCollection:
                 )
             ),
             CategoricalGridCondition(
-                HyperParameter(
+                Parameter(
                     {
                         "name": "x0",
-                        "type": "CATEGORICAL",
+                        "type": "categorical",
                         "choices": [0, 1, 2]
                     }
                 )
@@ -634,10 +632,10 @@ class TestGridConditionCollection:
     def test_set_num_choices(self, monkeypatch: pytest.MonkeyPatch) -> None:
         conditions = [
             FloatGridCondition(
-                HyperParameter(
+                Parameter(
                     {
                         "name": "x1",
-                        "type": "FLOAT",
+                        "type": "uniform_float",
                         "lower": 0.0,
                         "upper": 1.0,
                         "log": False

--- a/tests/unit/optimizer_test/test_nelder_mead.py
+++ b/tests/unit/optimizer_test/test_nelder_mead.py
@@ -96,7 +96,7 @@ class TestNelderMead(BaseTest):
                     trial_id=i,
                     param_name=f'x{j+1}',
                     param_value=0.0,
-                    param_type='float'
+                    param_type='uniform_float'
                 )
         storage.trial.set_any_trial_state(trial_id=1, state='finished')
         #

--- a/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
+++ b/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
@@ -4,10 +4,9 @@ import numpy as np
 import pytest
 
 from aiaccel.common import goal_maximize
+from aiaccel.converted_parameter import ConvertedParameterConfiguration
+from aiaccel.optimizer import NelderMead, NelderMeadOptimizer
 from aiaccel.parameter import HyperParameterConfiguration
-from aiaccel.optimizer import NelderMead
-from aiaccel.optimizer import NelderMeadOptimizer
-
 from tests.base_test import BaseTest
 
 
@@ -67,7 +66,10 @@ class TestNelderMeadOptimizer(BaseTest):
         self.optimizer.pre_process()
         # config = load_test_config()
         config = self.load_config_for_test(self.configs["config_nelder_mead.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(
             self.optimizer.params.get_parameter_list(),
@@ -87,7 +89,7 @@ class TestNelderMeadOptimizer(BaseTest):
         self.optimizer.generate_initial_parameter()
         with patch.object(self.optimizer, 'nelder_mead_main', return_value=[]):
             with patch.object(self.optimizer, 'parameter_pool', []):
-                assert self.optimizer.generate_parameter() == []
+                assert self.optimizer.generate_parameter() is None
 
     def test_generate_parameter2(
         self,
@@ -96,7 +98,10 @@ class TestNelderMeadOptimizer(BaseTest):
     ):
         self.optimizer.pre_process()
         config = self.load_config_for_test(self.configs["config.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(
             self.optimizer.params.get_parameter_list(),
@@ -114,7 +119,10 @@ class TestNelderMeadOptimizer(BaseTest):
     ):
         self.optimizer.pre_process()
         config = self.load_config_for_test(self.configs["config.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(
             self.optimizer.params.get_parameter_list(),
@@ -135,7 +143,10 @@ class TestNelderMeadOptimizer(BaseTest):
         self.optimizer.pre_process()
         config = load_test_config_org()
         config = self.load_config_for_test(self.configs["config.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
 
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(

--- a/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
+++ b/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
@@ -20,16 +20,16 @@ class TestNelderMeadOptimizer(BaseTest):
 
     def test_generate_initial_parameter(self):
         expected = [
-            {'parameter_name': 'x1', 'type': 'FLOAT', 'value': 0.74},
-            {'parameter_name': 'x2', 'type': 'FLOAT', 'value': 2.98},
-            {'parameter_name': 'x3', 'type': 'FLOAT', 'value': 3.62},
-            {'parameter_name': 'x4', 'type': 'FLOAT', 'value': 0.9},
-            {'parameter_name': 'x5', 'type': 'FLOAT', 'value': 1.99},
-            {'parameter_name': 'x6', 'type': 'FLOAT', 'value': -2.78},
-            {'parameter_name': 'x7', 'type': 'FLOAT', 'value': 1.0},
-            {'parameter_name': 'x8', 'type': 'FLOAT', 'value': 4.97},
-            {'parameter_name': 'x9', 'type': 'FLOAT', 'value': 1.98},
-            {'parameter_name': 'x10', 'type': 'FLOAT', 'value': 4.03}
+            {'parameter_name': 'x1', 'type': 'uniform_float', 'value': 0.74},
+            {'parameter_name': 'x2', 'type': 'uniform_float', 'value': 2.98},
+            {'parameter_name': 'x3', 'type': 'uniform_float', 'value': 3.62},
+            {'parameter_name': 'x4', 'type': 'uniform_float', 'value': 0.9},
+            {'parameter_name': 'x5', 'type': 'uniform_float', 'value': 1.99},
+            {'parameter_name': 'x6', 'type': 'uniform_float', 'value': -2.78},
+            {'parameter_name': 'x7', 'type': 'uniform_float', 'value': 1.0},
+            {'parameter_name': 'x8', 'type': 'uniform_float', 'value': 4.97},
+            {'parameter_name': 'x9', 'type': 'uniform_float', 'value': 1.98},
+            {'parameter_name': 'x10', 'type': 'uniform_float', 'value': 4.03}
         ]
 
         _optimizer = NelderMeadOptimizer(self.load_config_for_test(self.configs["config.json"]))

--- a/tests/unit/optimizer_test/test_tpe_optimizer.py
+++ b/tests/unit/optimizer_test/test_tpe_optimizer.py
@@ -4,9 +4,9 @@ import numpy as np
 import pytest
 
 from aiaccel.config import load_config
-from aiaccel.parameter import HyperParameterConfiguration
 from aiaccel.optimizer import TpeOptimizer
 from aiaccel.optimizer.tpe_optimizer import TPESamplerWrapper, create_distributions
+from aiaccel.parameter import HyperParameterConfiguration
 from tests.base_test import BaseTest
 
 
@@ -98,6 +98,7 @@ def test_create_distributions(data_dir):
     assert type(dist) is dict
 
     config = load_config(data_dir / 'config_tpe_invalid_type.json')
-    params = HyperParameterConfiguration(config.optimize.parameters)
+
     with pytest.raises(TypeError):
+        params = HyperParameterConfiguration(config.optimize.parameters)
         create_distributions(params)

--- a/tests/unit/scheduler_test/job_test/test_job_thread.py
+++ b/tests/unit/scheduler_test/job_test/test_job_thread.py
@@ -1,20 +1,19 @@
 import asyncio
 import datetime
 import time
-
-from aiaccel.config import ResourceType
-
 from subprocess import Popen
 
 import pytest
 
 from aiaccel.common import (dict_hp_finished, dict_hp_ready, dict_hp_running,
-                            dict_runner)
+                            dict_lock, dict_result, dict_runner, goal_maximize,
+                            goal_minimize)
+from aiaccel.config import ResourceType
 from aiaccel.scheduler import (AbciModel, CustomMachine, Job, LocalModel,
                                LocalScheduler, create_scheduler)
 from aiaccel.util import get_time_now_object
-from tests.base_test import BaseTest
 from aiaccel.util.process import OutputHandler
+from tests.base_test import BaseTest
 
 
 async def async_start_job(job):
@@ -192,55 +191,6 @@ class TestModel(BaseTest):
     def test_after_finished(self, database_remove):
         assert self.model.after_finished(self.job) is None
 
-    """
-    def test_before_finished(
-        self,
-        setup_hp_running,
-        setup_result,
-        work_dir,
-        database_remove
-    ):
-        # setup_hp_running(0)
-        # setup_result(0)
-        # print(self.job.trial_id_str)
-        # print(self.storage.result.get_result_trial_id_list())
-        print(self.job.storage.result.get_all_result())
-        for i in range(10):
-            self.job.storage.result.set_any_trial_objective(trial_id=i, objective=i*1.0)
-            for j in range(10):
-                self.job.storage.hp.set_any_trial_param(
-                    trial_id=i,
-                    param_name=f'x{j+1}',
-                    param_value=0.0,
-                    param_type='float'
-                )
-        assert self.model.before_finished(self.job) is None
-
-        # self.job.storage.trial.all_delete()
-        # self.job.storage.hp.all_delete()
-
-        # setup_hp_running(1)
-        # setup_result(1)
-
-        for i in range(10):
-            self.job.storage.trial.set_any_trial_state(trial_id=i, state='finished')
-            for j in range(10):
-                self.job.storage.hp.set_any_trial_param(
-                    trial_id=i,
-                    param_name=f'x{j+1}',
-                    param_value=0.0,
-                    param_type='float'
-                )
-        print(self.job.trial_id)
-        print([d.objective for d in self.job.storage.result.get_all_result()])
-        print(self.job.storage.get_best_trial_dict('minimize'))
-
-        self.job.next_state = 'finished'
-        self.job.from_file = work_dir.joinpath(dict_hp_running, '001.hp')
-        self.job.to_file = work_dir.joinpath(dict_hp_finished, '001.hp')
-        assert self.model.before_finished(self.job) is None
-    """
-
     def test_before_finished(
         self,
         setup_hp_running,
@@ -258,19 +208,10 @@ class TestModel(BaseTest):
             self.job.storage.hp.set_any_trial_params(
                 trial_id=i,
                 params=[
-                    {'parameter_name': f'x{j+1}', 'value': 0.0, 'type': 'float'}
+                    {'parameter_name': f'x{j+1}', 'value': 0.0, 'type': 'uniform_float'}
                     for j in range(10)
                 ]
             )
-            """
-            for j in range(10):
-                self.job.storage.hp.set_any_trial_param(
-                    trial_id=i,
-                    param_name=f'x{j+1}',
-                    param_value=0.0,
-                    param_type='float'
-                )
-            """
         assert self.model.before_finished(self.job) is None
 
         # self.job.storage.trial.all_delete()
@@ -284,19 +225,10 @@ class TestModel(BaseTest):
             self.job.storage.hp.set_any_trial_params(
                 trial_id=i,
                 params=[
-                    {'parameter_name': f'x{j+1}', 'value': 0.0, 'type': 'float'}
+                    {'parameter_name': f'x{j+1}', 'value': 0.0, 'type': 'uniform_float'}
                     for j in range(10)
                 ]
             )
-            """
-            for j in range(10):
-                self.job.storage.hp.set_any_trial_param(
-                    trial_id=i,
-                    param_name=f'x{j+1}',
-                    param_value=0.0,
-                    param_type='float'
-                )
-            """
 
         self.job.next_state = 'finished'
         self.job.from_file = work_dir.joinpath(dict_hp_running, '001.hp')

--- a/tests/unit/test_converted_parameter.py
+++ b/tests/unit/test_converted_parameter.py
@@ -26,7 +26,7 @@ from aiaccel.converted_parameter import (
     _restore_float,
     _restore_int,
 )
-from aiaccel.parameter import HyperParameter, HyperParameterConfiguration
+from aiaccel.parameter import HyperParameterConfiguration, Parameter
 
 float_parameter_dict = {
     "name": "x0",
@@ -64,10 +64,10 @@ ordinal_parameter_dict = {
 class BaseTestConvertedParameter:
     @pytest.fixture(autouse=True)
     def setup(self) -> Generator[None, None, None]:
-        self.float_param = HyperParameter(float_parameter_dict)
-        self.int_param = HyperParameter(int_parameter_dict)
-        self.categorical_param = HyperParameter(categorical_parameter_dict)
-        self.ordinal_param = HyperParameter(ordinal_parameter_dict)
+        self.float_param = Parameter(float_parameter_dict)
+        self.int_param = Parameter(int_parameter_dict)
+        self.categorical_param = Parameter(categorical_parameter_dict)
+        self.ordinal_param = Parameter(ordinal_parameter_dict)
 
         self._rng = RandomState(42)
 
@@ -447,7 +447,7 @@ def test_make_weight_name() -> None:
 
 
 def test_convert_numerics(monkeypatch: pytest.MonkeyPatch) -> None:
-    param = ConvertedFloatParameter(HyperParameter(float_parameter_dict))
+    param = ConvertedFloatParameter(Parameter(float_parameter_dict))
 
     with monkeypatch.context() as m:
         m.setattr(param, "convert_log", True)
@@ -465,7 +465,7 @@ def test_convert_numerics(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_convert_float() -> None:
-    param = ConvertedFloatParameter(HyperParameter(float_parameter_dict))
+    param = ConvertedFloatParameter(Parameter(float_parameter_dict))
 
     value_by_convert_float = _convert_float(param, 1.0)
     value_by_convert_numerics = _convert_numerics(param, 1.0)
@@ -474,7 +474,7 @@ def test_convert_float() -> None:
 
 
 def test_convert_int(monkeypatch: pytest.MonkeyPatch) -> None:
-    param = ConvertedIntParameter(HyperParameter(int_parameter_dict))
+    param = ConvertedIntParameter(Parameter(int_parameter_dict))
 
     with monkeypatch.context() as m:
         m.setattr(param, "convert_int", True)
@@ -490,7 +490,7 @@ def test_convert_int(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_restore_float(monkeypatch: pytest.MonkeyPatch) -> None:
-    param = ConvertedFloatParameter(HyperParameter(float_parameter_dict))
+    param = ConvertedFloatParameter(Parameter(float_parameter_dict))
 
     with monkeypatch.context() as m:
         m.setattr(param, "convert_log", True)
@@ -504,7 +504,7 @@ def test_restore_float(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_restore_int(monkeypatch: pytest.MonkeyPatch) -> None:
-    param = ConvertedIntParameter(HyperParameter(int_parameter_dict))
+    param = ConvertedIntParameter(Parameter(int_parameter_dict))
 
     with monkeypatch.context() as m:
         m.setattr(param, "convert_log", True)
@@ -520,7 +520,7 @@ def test_restore_int(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_is_weight_collected() -> None:
-    param = WeightOfChoice(HyperParameter(categorical_parameter_dict), 0)
+    param = WeightOfChoice(Parameter(categorical_parameter_dict), 0)
     weights = {
         param.original_name: {f"{param.name}_{i}": i * 0.1 for i in range(len(param.choices))}
     }
@@ -532,7 +532,7 @@ def test_is_weight_collected() -> None:
 
 
 def test_make_weight_distribution() -> None:
-    param = WeightOfChoice(HyperParameter(categorical_parameter_dict), 0)
+    param = WeightOfChoice(Parameter(categorical_parameter_dict), 0)
     weights = {
         param.original_name: {f"{param.original_name}_{i}": i * 0.1 for i in range(len(param.choices))}
     }
@@ -541,14 +541,14 @@ def test_make_weight_distribution() -> None:
 
 
 def test_decode_weight_distribution() -> None:
-    param = WeightOfChoice(HyperParameter(categorical_parameter_dict), 0)
+    param = WeightOfChoice(Parameter(categorical_parameter_dict), 0)
     weight_distribution = [1] + [0] * (len(param.choices) - 1)
     choosed_value = _decode_weight_distribution(param, weight_distribution)
     assert choosed_value == param.choices[0]
 
 
 def test_make_structured_value() -> None:
-    param = ConvertedFloatParameter(HyperParameter(float_parameter_dict))
+    param = ConvertedFloatParameter(Parameter(float_parameter_dict))
     value = param.lower
     structured_value = _make_structured_value(param, value)
     assert structured_value.get("parameter_name") == param.name

--- a/tests/unit/test_parameter.py
+++ b/tests/unit/test_parameter.py
@@ -18,17 +18,6 @@ class TestParameter(BaseTest):
         assert ps.name == 'x3'
 
     def test_sample(self):
-        # json_string = {
-        #     'parameters': [
-        #         {'name': 'a', 'type': 'uniform_int', 'lower': 0, 'upper': 10},
-        #         {'name': 'b', 'type': 'uniform_float', 'lower': 0.,
-        #          'upper': 10.},
-        #         {'name': 'c', 'type': 'categorical',
-        #          'choices': ['red', 'green', 'blue']},
-        #         {'name': 'd', 'type': 'ordinal',
-        #          'sequence': ['10', '20', '30']}
-        #     ]
-        # }
         json_string = [
             {
                 'name': 'a',
@@ -66,10 +55,8 @@ class TestParameter(BaseTest):
         assert len(p) == 4
 
         json_string.append({'name': 'e', 'type': 'invalid'})
-        hp = HyperParameterConfiguration(json_string)
-
         try:
-            hp.sample(rng=rng)
+            hp = HyperParameterConfiguration(json_string)
             assert False
         except TypeError:
             assert True


### PR DESCRIPTION
Currently, the HyperParameter class replaces the hyperparameter data types of uniform_int, uniform_float, categorical, and ordinal with the strings INT, FLOAT, CATEGORICAL, and ORDINAL, respectively. However, this process is actually unnecessary, so I removed it.

<hr>

現状、HyperParameterクラスではuniform_int、uniform_float、categorical、ordinalのハイパーパラメーターデータ型を表現するため、それぞれをINT、FLOAT、CATEGORICAL、ORDINALの文字列に置き換える処理が実行されていますが，実際にはこの処理は不要であるため，削除しました．

<hr>

close # 273