### PR TITLE
Make multi-objective optimization available in some optimizers

### DIFF
--- a/aiaccel/optimizer/grid_optimizer.py
+++ b/aiaccel/optimizer/grid_optimizer.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from omegaconf.dictconfig import DictConfig
 
-from aiaccel.config import is_multi_objective
 from aiaccel.optimizer import AbstractOptimizer
 from aiaccel.parameter import HyperParameter
 
@@ -132,12 +131,6 @@ class GridOptimizer(AbstractOptimizer):
         for param in self.params.get_parameter_list():
             self.ready_params.append(generate_grid_points(param, self.config))
         self.generate_index = 0
-
-        if is_multi_objective(self.config):
-            raise NotImplementedError(
-                'Grid search optimizer does not support multi-objective '
-                'optimization.'
-            )
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.

--- a/aiaccel/optimizer/random_optimizer.py
+++ b/aiaccel/optimizer/random_optimizer.py
@@ -1,24 +1,12 @@
 from __future__ import annotations
 
-from aiaccel.config import is_multi_objective
 from aiaccel.optimizer import AbstractOptimizer
-
-from omegaconf.dictconfig import DictConfig
 
 
 class RandomOptimizer(AbstractOptimizer):
     """An optimizer class with a random algorithm.
 
     """
-
-    def __init__(self, config: DictConfig) -> None:
-        super().__init__(config)
-
-        if is_multi_objective(self.config):
-            raise NotImplementedError(
-                'Random optimizer does not support multi-objective '
-                'optimization.'
-            )
 
     def generate_parameter(self) -> list[dict[str, float | int | str]]:
         """Generate parameters.

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from scipy.stats import qmc
 
-from aiaccel.config import is_multi_objective
 from aiaccel.optimizer import AbstractOptimizer
 
 
@@ -30,12 +29,6 @@ class SobolOptimizer(AbstractOptimizer):
         super().__init__(config)
         self.generate_index: Any = None
         self.sampler: Any = None
-
-        if is_multi_objective(self.config):
-            raise NotImplementedError(
-                'Sobol optimizer does not support multi-objective '
-                'optimization.'
-            )
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.


### PR DESCRIPTION
一部のオプティマイザで，多目的最適化を実行可能にします．
この PR で，多目的最適化が可能になるのは以下の３つのオプティマイザです．
- `GridOptimizer`
- `RandomOptimizer`
- `SobolOptimizer`

これらのオプティマイザでは，コンストラクタで `is_multi_objective()` 関数が True を返す場合に `NotImprementedError` を発生させるようになっていましたが，この判定部分を削除しました．

また，`BudgetSpecifiedGridOptimizer` に関しては，もともと多目的最適化を禁止する機構が無かったため，他のオプティマイザと同様に，多目的最適化に用いることができます．

