### PR TITLE
Modify flake8 ignore opitons to extend-ignore E203.

### DIFF
--- a/.github/workflows/code_formatter.yaml
+++ b/.github/workflows/code_formatter.yaml
@@ -22,11 +22,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install black flake8 isort pycodestyle
 
-      - name: Pycodestyle Test
-        run: pycodestyle --max-line-length=120 --ignore=E203 aiaccel
-
       - name: Lint
         run: |
-          flake8 --max-line-length 120 --ignore E203 aiaccel
+          flake8 --max-line-length 120 --extend-ignore E203 aiaccel
           isort --check --diff --profile black aiaccel
           black --check --line-length 120 aiaccel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-        args: ["--max-line-length", "120", "--ignore", "E203", "aiaccel"]
+        args: ["--max-line-length", "120", "--extend-ignore", "E203", "aiaccel"]
         exclude:  ^(?:examples|tests)/.*
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ max-line-length = 120
 # E203: whitespace before ':'
 # E501: Line too long (82 > 79 characters)
 # W503: Line break occurred before a binary operator
-ignore = "E203,E501,W503"
+extend-ignore = E203
 
 [tool.mypy]
 python_version="3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,7 @@ line_length = 120
 [tool.flake8]
 max-line-length = 120
 # E203: whitespace before ':'
-# E501: Line too long (82 > 79 characters)
-# W503: Line break occurred before a binary operator
-extend-ignore = E203
+extend-ignore = "E203,"
 
 [tool.mypy]
 python_version="3.8"


### PR DESCRIPTION
Fix includes followings:
- Remove pycodestyle because it's included in flake8.
- Change flake8 ignore option to extend-ignore, it's add options to default opitons.

Black and flake8 ignore W503 by default opiton.