### PR TITLE
Feature/fix handling none

### DIFF
--- a/aiaccel/cli/set_result.py
+++ b/aiaccel/cli/set_result.py
@@ -83,6 +83,8 @@ def main() -> None:
     if args.error == "":
         del contents["error"]
 
+    contents["result"] = [None if res == "None" else res for res in contents["result"]]
+
     print(contents)
 
     create_yaml(args.file, contents)

--- a/aiaccel/storage/result.py
+++ b/aiaccel/storage/result.py
@@ -98,10 +98,20 @@ class Result(Abstract):
         bests = np.zeros((len(goals), len(objectives[0])))
 
         for i in range(len(goals)):
-            if goals[i].lower() == "maximize":
-                bests[i, :] = np.max(objectives[:, i], axis=0)
+            objs = []
+            for obj in objectives[:, i]:
+                try:
+                    float(obj)
+                except (ValueError, TypeError):
+                    continue
+                objs.append(obj)
+
+            if len(objs) == 0:
+                bests[i, :] = None
+            elif goals[i].lower() == "maximize":
+                bests[i, :] = np.max(objs, axis=0)
             elif goals[i].lower() == "minimize":
-                bests[i, :] = np.min(objectives[:, i], axis=0)
+                bests[i, :] = np.min(objs, axis=0)
             else:
                 raise ValueError("Invalid goal value.")
 

--- a/aiaccel/tensorboard/tensorboard.py
+++ b/aiaccel/tensorboard/tensorboard.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import os
+from logging import StreamHandler, getLogger
+
 from omegaconf.dictconfig import DictConfig
 from tensorboardX import SummaryWriter
 
 from aiaccel.common import goal_maximize
 from aiaccel.module import AbstractModule
 from aiaccel.util.buffer import Buffer
-from aiaccel.util.trialid import TrialId
+
+logger = getLogger(__name__)
+logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))
+logger.addHandler(StreamHandler())
 
 
 class TensorBoard(AbstractModule):
@@ -30,6 +36,14 @@ class TensorBoard(AbstractModule):
         self.buff.d["finished"].set_max_len(2)
 
     def pre_process(self) -> None:
+        # To avoid issues with graph rendering,
+        # when providing an ID with 4-6 digits to the name parameter of add_hparams,
+        # it is recommended to use a 7-digit ID by padding with leading zeros if necessary.
+
+        self.name_length = self.config.job_setting.name_length
+        if self.name_length < 7:
+            logger.warning("Within Tensor Board, the name_length is treated as 7.")
+            self.name_length = 7
         return None
 
     def inner_loop_main_process(self) -> bool:
@@ -54,6 +68,8 @@ class TensorBoard(AbstractModule):
             if objective_ys is None or best_values is None:
                 continue
 
+            tag_objectives = {}
+
             for i in range(len(self.goals)):
                 goal = self.goals[i]
                 objective_y = objective_ys[i]
@@ -66,14 +82,20 @@ class TensorBoard(AbstractModule):
                     tag_objective = f"objective_{i}_"
                     tag_min_or_max = f"maximum_{i}_" if goal == goal_maximize else f"minimum_{i}_"
 
-                self.writer.add_scalar(tag=tag_objective, scalar_value=objective_y, global_step=trial_id)
+                if objective_y is None:
+                    self.writer.add_scalar(tag=tag_objective, scalar_value=float("nan"), global_step=trial_id)
+                else:
+                    self.writer.add_scalar(tag=tag_objective, scalar_value=objective_y, global_step=trial_id)
                 self.writer.add_scalar(tag=tag_min_or_max, scalar_value=best_value, global_step=trial_id)
 
                 # hyperparameters
                 params = self.storage.hp.get_any_trial_params_dict(trial_id)
-                _trial_id = TrialId(self.config).zero_padding_any_trial_id(trial_id)
+                _trial_id = self.zero_padding(trial_id)
 
-                self.writer.add_hparams(params, {tag_objective: objective_y}, name=_trial_id)
+                if objective_y is not None:
+                    tag_objectives[f"hparam/{tag_objective}"] = objective_y
+
+            self.writer.add_hparams(params, tag_objectives, name=_trial_id)
 
             self.writer.flush()
 
@@ -82,3 +104,6 @@ class TensorBoard(AbstractModule):
     def post_process(self) -> None:
         self.writer.close()
         return None
+
+    def zero_padding(self, trial_id: int) -> str:
+        return f"%0{self.name_length}d" % trial_id


### PR DESCRIPTION
ユーザプログラムが None を返した際に、エラーが出る・想定外の挙動を取る現象を修正しました。

- MOTPE 等の多目的最適化をtype: localで実行した場合、(1.0, None)のような片方の目的関数の結果がNoneだった時に、type: localの時、None はファイル読み書きの都合でstrとして扱われるので、コード内では (1.0, "None") のように扱われます。
  - aiaccel/storage/result.py 内の97行目のように np.array((1.0, "None")) を実行した際に、"None" が str である影響で 1.0 も str 扱いされて、その後の比較処理の部分でエラーになっていました。
  - type: pylocalの場合は、Noneは通常のNoneとして扱われるため、そちらに合わせる意図も込みで type:localの時も None を通常の None として扱うように aiaccel/cli/set_result.py を改修しました。
    - 文字列の"None" を通常の None に変換する処理を追加しています。
- aiaccel/storage/result.py 内97行目の objectives に None が含まれている場合、そのまま np.max(もしくは np.min)を実行すると None との比較が発生しエラーになるため、objectivesからNoneを除外する処理を追加しました。
- (1.0, None)のような片方の目的関数の結果がNoneのような結果が含まれるaiaccelの結果をtensor boardで表示した時、パラメータと結果の組のテーブル表示が乱れることがありました。
  - 例えば、下記のような結果をtensor boardで可視化しようとした際に、
![Screenshot from 2023-05-09 16-08-35](https://user-images.githubusercontent.com/105629713/237020988-a61b1127-f601-4224-b5eb-6673538f8d79.png)
  - テーブルは以下のようになり、2番目のresultの値が表示されなくなります。
![Screenshot from 2023-05-09 16-11-03](https://user-images.githubusercontent.com/105629713/237021352-c4a08ae9-e0fb-4834-8e7e-79803d11c12b.png)
  - このようになる原因の詳細は不明ですが、trial id の欄を 00000X のような0が連続する4~6桁の表記にすると発生する模様です。（tensor board単体のコードでも再現しました。tensor board 内部の何かと値が競合している可能性があります。）
  - trial id の欄を 000000X のような7桁の表記にすると、以下のように正常に表示される(Noneの箇所は空欄)ので、暫定処理としてデフォルト設定を7桁とし、6桁以下の設定の場合は7桁表示に変更するように修正しました。
![Screenshot from 2023-05-09 16-27-04](https://user-images.githubusercontent.com/105629713/237025026-228b60f8-6789-4e69-b5d2-a4cce0f54491.png)
