### PR TITLE
Fix parameter conversion

### DIFF
--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -72,8 +72,8 @@ class ParameterConfig:
     upper: Union[float, int]
     # initial: Optional[Union[None, float, int, str, List[Union[float, int]]]]  # Unions of containers are not supported
     initial: Optional[Any]
-    choices: Optional[List[Any]]
-    sequence: Optional[List[Any]]
+    choices: Optional[List[str]]
+    sequence: Optional[List[float]]
     log: Optional[bool]
     base: Optional[int]
     step: Optional[Union[int, float]]

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -72,8 +72,8 @@ class ParameterConfig:
     upper: Union[float, int]
     # initial: Optional[Union[None, float, int, str, List[Union[float, int]]]]  # Unions of containers are not supported
     initial: Optional[Any]
-    choices: Optional[List[Union[None, float, int, str]]]
-    sequence: Optional[List[Union[None, float, int, str]]]
+    choices: Optional[List[Any]]
+    sequence: Optional[List[Any]]
     log: Optional[bool]
     base: Optional[int]
     step: Optional[Union[int, float]]

--- a/aiaccel/converted_parameter.py
+++ b/aiaccel/converted_parameter.py
@@ -100,7 +100,7 @@ class WeightOfChoice(ConvertedParameter):
         self.choice_index = choice_index
         self.original_name = self.name
         self.name = _make_weight_name(self.original_name, choice_index)
-        self.choices = param.choices if param.type.lower() == "categorical" else param.sequence
+        self.choices = list(param.choices if param.type.lower() == "categorical" else param.sequence)
         self.lower = 0.0
         self.upper = 1.0
         if isinstance(param.initial, Iterable) and not isinstance(param.initial, str):  # For Nelder-Mead
@@ -208,7 +208,8 @@ class ConvertedParameterConfiguration(HyperParameterConfiguration):
                         converted_params[converted_param.name] = converted_param
                     logger = getLogger("root.optimizer")
                     logger.warning(
-                        f"The choices of {param.name} is converted to {len(param.choices)} float parameters."
+                        f"The choices of {param.name} ({param.type}) is converted to "
+                        f"{len(param.choices)} float parameters."
                     )
                 else:
                     converted_params[param.name] = ConvertedCategoricalParameter(param, convert_choices=convert_choices)
@@ -219,7 +220,8 @@ class ConvertedParameterConfiguration(HyperParameterConfiguration):
                         converted_params[converted_param.name] = converted_param
                     logger = getLogger("root.optimizer")
                     logger.warning(
-                        f"The sequence of {param.name} is converted to {len(param.sequence)} float parameters."
+                        f"The sequence of {param.name} ({param.type}) is converted to "
+                        f"{len(param.sequence)} float parameters."
                     )
                 else:
                     converted_params[param.name] = ConvertedOrdinalParameter(param, convert_sequence=convert_sequence)
@@ -377,4 +379,8 @@ def _decode_weight_distribution(param: WeightOfChoice, weight_distribution: list
 
 
 def _make_structured_value(param: ConvertedParameter, value: Any) -> dict[str, Any]:
-    return {"parameter_name": param.name, "type": param.type, "value": value}
+    return {
+        "parameter_name": param.original_name if isinstance(param, WeightOfChoice) else param.name,
+        "type": param.type,
+        "value": value,
+    }

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -215,7 +215,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
         searched_params = self.nelder_mead_main()
 
         if searched_params is None:
-            return None
+            return []
 
         for p in searched_params:
             if p["vertex_id"] not in self._get_all_trial_id() and p["vertex_id"] not in self._get_current_names():

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -215,7 +215,7 @@ class NelderMeadOptimizer(AbstractOptimizer):
         searched_params = self.nelder_mead_main()
 
         if searched_params is None:
-            return []
+            return None
 
         for p in searched_params:
             if p["vertex_id"] not in self._get_all_trial_id() and p["vertex_id"] not in self._get_current_names():

--- a/aiaccel/optimizer/sobol_optimizer.py
+++ b/aiaccel/optimizer/sobol_optimizer.py
@@ -26,11 +26,11 @@ class SobolOptimizer(AbstractOptimizer):
 
     def __init__(self, config: DictConfig) -> None:
         super().__init__(config)
+        self.params: ConvertedParameterConfiguration = ConvertedParameterConfiguration(self.params)
         self.num_generated_params = 0
         self.sampler = qmc.Sobol(
             d=len(self.params.get_parameter_list()), scramble=self.config.optimize.sobol_scramble, seed=self._rng
         )
-        self.params: ConvertedParameterConfiguration = ConvertedParameterConfiguration(self.params)
 
     def pre_process(self) -> None:
         """Pre-procedure before executing processes.

--- a/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
+++ b/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
@@ -4,10 +4,9 @@ import numpy as np
 import pytest
 
 from aiaccel.common import goal_maximize
+from aiaccel.converted_parameter import ConvertedParameterConfiguration
+from aiaccel.optimizer import NelderMead, NelderMeadOptimizer
 from aiaccel.parameter import HyperParameterConfiguration
-from aiaccel.optimizer import NelderMead
-from aiaccel.optimizer import NelderMeadOptimizer
-
 from tests.base_test import BaseTest
 
 
@@ -67,7 +66,10 @@ class TestNelderMeadOptimizer(BaseTest):
         self.optimizer.pre_process()
         # config = load_test_config()
         config = self.load_config_for_test(self.configs["config_nelder_mead.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(
             self.optimizer.params.get_parameter_list(),
@@ -96,7 +98,10 @@ class TestNelderMeadOptimizer(BaseTest):
     ):
         self.optimizer.pre_process()
         config = self.load_config_for_test(self.configs["config.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(
             self.optimizer.params.get_parameter_list(),
@@ -114,7 +119,10 @@ class TestNelderMeadOptimizer(BaseTest):
     ):
         self.optimizer.pre_process()
         config = self.load_config_for_test(self.configs["config.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(
             self.optimizer.params.get_parameter_list(),
@@ -135,7 +143,10 @@ class TestNelderMeadOptimizer(BaseTest):
         self.optimizer.pre_process()
         config = load_test_config_org()
         config = self.load_config_for_test(self.configs["config.json"])
-        self.optimizer.params = HyperParameterConfiguration(config.optimize.parameters)
+        self.optimizer.params = ConvertedParameterConfiguration(
+            HyperParameterConfiguration(config.optimize.parameters), convert_log=True, convert_int=True,
+            convert_choices=True, convert_sequence=True,
+        )
 
         rng = np.random.RandomState(0)
         self.optimizer.nelder_mead = NelderMead(

--- a/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
+++ b/tests/unit/optimizer_test/test_nelder_mead_optimizer.py
@@ -89,7 +89,7 @@ class TestNelderMeadOptimizer(BaseTest):
         self.optimizer.generate_initial_parameter()
         with patch.object(self.optimizer, 'nelder_mead_main', return_value=[]):
             with patch.object(self.optimizer, 'parameter_pool', []):
-                assert self.optimizer.generate_parameter() == []
+                assert self.optimizer.generate_parameter() is None
 
     def test_generate_parameter2(
         self,


### PR DESCRIPTION
Fix that `ConvertedParameter` (implemented by #275) is not applied well.

In addition to this, type annotation in `config.py` is changed for avioding errors originating from `omegaconf.base.UnionNode`.
Specifically, the type annotations of `ParameterConfig.choices` and `ParameterConfig.sequence` are changed ~to `Optional[List[Any]]`~ to `Optional[List[str]]` and `Optional[List[float]]`, respectively.
This is because, omegaconf can not cast `List[Union[float, int]]` to either `list[float]` nor `list[int]`, but casts only to `list[UnionNode]`.
This causes errors in `filesystem`, `TpeOptimizer`, user program (if python_local), or where functions like `float()` are called with any content of `choices` or `sequence`.
