### PR TITLE
Fix typo in set_result.py

### DIFF
--- a/aiaccel/cli/set_result.py
+++ b/aiaccel/cli/set_result.py
@@ -70,7 +70,7 @@ def main() -> None:
     contents = {
         "trial_id": args.trial_id,
         "result": args.objective,
-        "paramerters": xs,
+        "parameters": xs,
         "start_time": args.start_time,
         "end_time": args.end_time,
         "exitcode": args.exitcode,


### PR DESCRIPTION
Fixed a spelling mistake for a key of dict regarding a yaml file to store result data.