### PR TITLE
Fix getting results in ABCI mode.

### DIFF
--- a/aiaccel/abci/batch.py
+++ b/aiaccel/abci/batch.py
@@ -87,7 +87,7 @@ def create_abci_batch_file(
         f"output_file_path={str(output_file_path)}",
         f"error_file_path={str(error_file_path)}",
         'start_time=`date "+%Y-%m-%d %H:%M:%S"`',
-        f'result=`{" ".join(commands)}`',
+        f'result=$({" ".join(commands)} | tail -n 1)',
         "exitcode=$?",
         'ys=$(echo $result | tr -d "[],")',
         "error=`cat $error_file_path`",

--- a/aiaccel/util/aiaccel.py
+++ b/aiaccel/util/aiaccel.py
@@ -201,7 +201,7 @@ class Run:
             err (str): Error string.
         """
 
-        sys.stdout.write(f"{y}\n")
+        sys.stdout.write(f"\n{y}\n")
         if err != "":
             sys.stderr.write(f"{err}\n")
             exit(1)


### PR DESCRIPTION
type:ABCIでprint文を含んだ（標準出力を含んだ？）ユーザプログラムを実行した際に、そのprint文の内容も result に出力される現象を修正しました。

- 修正前のコードでは、下記のようにuser.pyの標準出力をすべてresultとして受け取り、objectiveに当たる部分の抽出無しでデータベースへの書き込みを行っていたため、result にユーザプログラムのprint文の内容が混ざる現象が起きていました。（#299）
```
result=`python user.py・・・`
```
- 修正版のコードでは、user.pyの最後の標準出力が objective に該当する実装になっているため、下記のように tail コマンドで最終行だけをresult として受け取るようにしました。
```
result=`python user.py・・・ | tail -n 1`
```
https://github.com/aistairc/aiaccel/blob/73c65ae5c469d20d15b40fc77c877d73161968f0/aiaccel/abci/batch.py#L90

- また、ユーザプログラムの標準出力に依存せず、最終行に result のみをprintするため、aiaccel/util/aiaccel.py  の Run.report で result を print する直前に改行コードを追加しました。

https://github.com/aistairc/aiaccel/blob/73c65ae5c469d20d15b40fc77c877d73161968f0/aiaccel/util/aiaccel.py#L204

close #299 