### PR TITLE
Fix issue with optional arguments that are negative numbers and in exponential notation

### DIFF
--- a/aiaccel/abci/batch.py
+++ b/aiaccel/abci/batch.py
@@ -16,7 +16,7 @@ def create_abci_batch_file(
     batch_file: Path,
     job_script_preamble: Path | str | None,
     command: str,
-    enable_command_argument: bool,
+    enable_name_in_optional_argument: bool,
     dict_lock: Path,
 ) -> None:
     """Create a ABCI batch file.
@@ -41,7 +41,7 @@ def create_abci_batch_file(
     """
 
     commands = re.split(" +", command)
-    if enable_command_argument:
+    if enable_name_in_optional_argument:
         for param in param_content["parameters"]:
             if "parameter_name" in param.keys() and "value" in param.keys():
                 commands.append(f'--{param["parameter_name"]}=${param["parameter_name"]}')

--- a/aiaccel/abci/batch.py
+++ b/aiaccel/abci/batch.py
@@ -16,7 +16,7 @@ def create_abci_batch_file(
     batch_file: Path,
     job_script_preamble: Path | str | None,
     command: str,
-    enable_name_in_optional_argument: bool,
+    enabled_variable_name_argumentation: bool,
     dict_lock: Path,
 ) -> None:
     """Create a ABCI batch file.
@@ -41,7 +41,7 @@ def create_abci_batch_file(
     """
 
     commands = re.split(" +", command)
-    if enable_name_in_optional_argument:
+    if enabled_variable_name_argumentation:
         for param in param_content["parameters"]:
             if "parameter_name" in param.keys() and "value" in param.keys():
                 commands.append(f'--{param["parameter_name"]}=${param["parameter_name"]}')

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -47,7 +47,7 @@ class GenericConfig:
     function: str
     batch_job_timeout: int
     sleep_time: Union[float, int]
-    enable_name_in_optional_argument: bool
+    enabled_variable_name_argumentation: bool
     is_ignore_warning: bool
 
 

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -47,7 +47,7 @@ class GenericConfig:
     function: str
     batch_job_timeout: int
     sleep_time: Union[float, int]
-    enable_command_argument: bool
+    enable_name_in_optional_argument: bool
     is_ignore_warning: bool
 
 

--- a/aiaccel/config.py
+++ b/aiaccel/config.py
@@ -47,6 +47,7 @@ class GenericConfig:
     function: str
     batch_job_timeout: int
     sleep_time: Union[float, int]
+    enable_command_argument: bool
     is_ignore_warning: bool
 
 

--- a/aiaccel/default_config.yaml
+++ b/aiaccel/default_config.yaml
@@ -5,7 +5,7 @@ generic:
     function: ''
     batch_job_timeout: 600
     sleep_time: 0.01
-    enable_command_argument: True
+    enable_name_in_optional_argument: True
     is_ignore_warning: True
 
 resource:

--- a/aiaccel/default_config.yaml
+++ b/aiaccel/default_config.yaml
@@ -5,6 +5,7 @@ generic:
     function: ''
     batch_job_timeout: 600
     sleep_time: 0.01
+    enable_command_argument: True
     is_ignore_warning: True
 
 resource:

--- a/aiaccel/default_config.yaml
+++ b/aiaccel/default_config.yaml
@@ -5,7 +5,7 @@ generic:
     function: ''
     batch_job_timeout: 600
     sleep_time: 0.01
-    enable_name_in_optional_argument: True
+    enabled_variable_name_argumentation: True
     is_ignore_warning: True
 
 resource:

--- a/aiaccel/experimental/mpi/config.py
+++ b/aiaccel/experimental/mpi/config.py
@@ -48,7 +48,7 @@ class GenericConfig:
     function: str
     batch_job_timeout: int
     sleep_time: Union[float, int]
-    enable_name_in_optional_argument: bool
+    enabled_variable_name_argumentation: bool
     is_ignore_warning: bool
 
 

--- a/aiaccel/experimental/mpi/config.py
+++ b/aiaccel/experimental/mpi/config.py
@@ -48,6 +48,7 @@ class GenericConfig:
     function: str
     batch_job_timeout: int
     sleep_time: Union[float, int]
+    enable_name_in_optional_argument: bool
     is_ignore_warning: bool
 
 

--- a/aiaccel/experimental/mpi/default_config.yaml
+++ b/aiaccel/experimental/mpi/default_config.yaml
@@ -5,7 +5,7 @@ generic:
     function: ''
     batch_job_timeout: 600
     sleep_time: 0.01
-    enable_name_in_optional_argument: True
+    enabled_variable_name_argumentation: True
     is_ignore_warning: True
 
 resource:

--- a/aiaccel/experimental/mpi/default_config.yaml
+++ b/aiaccel/experimental/mpi/default_config.yaml
@@ -5,6 +5,7 @@ generic:
     function: ''
     batch_job_timeout: 600
     sleep_time: 0.01
+    enable_name_in_optional_argument: True
     is_ignore_warning: True
 
 resource:

--- a/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
+++ b/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
@@ -19,7 +19,7 @@ class MpiModel(LocalModel):
             obj.trial_id,
             str(obj.config.config_path),
             str(obj.command_error_output),
-            obj.config.generic.enable_command_argument,
+            obj.config.generic.enable_name_in_optional_argument,
         )
 
         obj.logger.info(f'runner command: {" ".join(runner_command)}')

--- a/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
+++ b/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
@@ -19,7 +19,7 @@ class MpiModel(LocalModel):
             obj.trial_id,
             str(obj.config.config_path),
             str(obj.command_error_output),
-            obj.config.generic.enable_command_argument
+            obj.config.generic.enable_command_argument,
         )
 
         obj.logger.info(f'runner command: {" ".join(runner_command)}')

--- a/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
+++ b/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
@@ -19,7 +19,7 @@ class MpiModel(LocalModel):
             obj.trial_id,
             str(obj.config.config_path),
             str(obj.command_error_output),
-            obj.config.generic.enable_name_in_optional_argument,
+            obj.config.generic.enabled_variable_name_argumentation,
         )
 
         obj.logger.info(f'runner command: {" ".join(runner_command)}')

--- a/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
+++ b/aiaccel/experimental/mpi/scheduler/job/model/mpi_model.py
@@ -19,6 +19,7 @@ class MpiModel(LocalModel):
             obj.trial_id,
             str(obj.config.config_path),
             str(obj.command_error_output),
+            obj.config.generic.enable_command_argument
         )
 
         obj.logger.info(f'runner command: {" ".join(runner_command)}')
@@ -85,8 +86,7 @@ class MpiModel(LocalModel):
 
         commands = ["python", "-m", "aiaccel.experimental.mpi.cli.set_result"]
         for key in args.keys():
-            commands.append("--" + key)
-            commands.append(str(args[key]))
+            commands.append(f"--{key}={str(args[key])}")
 
         commands.append("--objective")
         for objective in objectives:
@@ -94,8 +94,7 @@ class MpiModel(LocalModel):
 
         for param in params:
             if "parameter_name" in param.keys() and "value" in param.keys():
-                commands.append("--" + param["parameter_name"])
-                commands.append(str(param["value"]))
+                commands.append(f"--{param['parameter_name']}={str(param['value'])}")
         print(commands)
         Popen(commands)
 

--- a/aiaccel/scheduler/job/model/abci_model.py
+++ b/aiaccel/scheduler/job/model/abci_model.py
@@ -24,7 +24,7 @@ class AbciModel(AbstractModel):
             batch_file=obj.to_file,
             job_script_preamble=obj.config.ABCI.job_script_preamble,
             command=obj.config.generic.job_command,
-            enable_command_argument=obj.config.generic.enable_command_argument,
+            enable_name_in_optional_argument=obj.config.generic.enable_name_in_optional_argument,
             dict_lock=obj.workspace.lock,
         )
 

--- a/aiaccel/scheduler/job/model/abci_model.py
+++ b/aiaccel/scheduler/job/model/abci_model.py
@@ -24,7 +24,7 @@ class AbciModel(AbstractModel):
             batch_file=obj.to_file,
             job_script_preamble=obj.config.ABCI.job_script_preamble,
             command=obj.config.generic.job_command,
-            enable_name_in_optional_argument=obj.config.generic.enable_name_in_optional_argument,
+            enabled_variable_name_argumentation=obj.config.generic.enabled_variable_name_argumentation,
             dict_lock=obj.workspace.lock,
         )
 

--- a/aiaccel/scheduler/job/model/abci_model.py
+++ b/aiaccel/scheduler/job/model/abci_model.py
@@ -24,6 +24,7 @@ class AbciModel(AbstractModel):
             batch_file=obj.to_file,
             job_script_preamble=obj.config.ABCI.job_script_preamble,
             command=obj.config.generic.job_command,
+            enable_command_argument=obj.config.generic.enable_command_argument,
             dict_lock=obj.workspace.lock,
         )
 

--- a/aiaccel/scheduler/job/model/local_model.py
+++ b/aiaccel/scheduler/job/model/local_model.py
@@ -28,6 +28,7 @@ class LocalModel(AbstractModel):
             obj.trial_id,
             str(obj.config.config_path),
             str(obj.command_error_output),
+            obj.config.generic.enable_command_argument,
         )
         obj.logger.info(f'runner command: {" ".join(runner_command)}')
         obj.proc = Popen(runner_command, stdout=PIPE, stderr=PIPE)
@@ -91,8 +92,7 @@ class LocalModel(AbstractModel):
 
         commands = ["aiaccel-set-result"]
         for key in args.keys():
-            commands.append("--" + key)
-            commands.append(str(args[key]))
+            commands.append(f"--{key}={str(args[key])}")
 
         commands.append("--objective")
         for objective in objectives:
@@ -100,9 +100,7 @@ class LocalModel(AbstractModel):
 
         for param in params:
             if "parameter_name" in param.keys() and "value" in param.keys():
-                commands.append("--" + param["parameter_name"])
-                commands.append(str(param["value"]))
-        print(commands)
+                commands.append(f"--{param['parameter_name']}={str(param['value'])}")
         Popen(commands)
 
         return None

--- a/aiaccel/scheduler/job/model/local_model.py
+++ b/aiaccel/scheduler/job/model/local_model.py
@@ -28,7 +28,7 @@ class LocalModel(AbstractModel):
             obj.trial_id,
             str(obj.config.config_path),
             str(obj.command_error_output),
-            obj.config.generic.enable_name_in_optional_argument,
+            obj.config.generic.enabled_variable_name_argumentation,
         )
         obj.logger.info(f'runner command: {" ".join(runner_command)}')
         obj.proc = Popen(runner_command, stdout=PIPE, stderr=PIPE)

--- a/aiaccel/scheduler/job/model/local_model.py
+++ b/aiaccel/scheduler/job/model/local_model.py
@@ -28,7 +28,7 @@ class LocalModel(AbstractModel):
             obj.trial_id,
             str(obj.config.config_path),
             str(obj.command_error_output),
-            obj.config.generic.enable_command_argument,
+            obj.config.generic.enable_name_in_optional_argument,
         )
         obj.logger.info(f'runner command: {" ".join(runner_command)}')
         obj.proc = Popen(runner_command, stdout=PIPE, stderr=PIPE)

--- a/aiaccel/scheduler/local_scheduler.py
+++ b/aiaccel/scheduler/local_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from typing import Any
 
 from aiaccel.scheduler.abstract_scheduler import AbstractScheduler
@@ -42,19 +43,21 @@ class LocalScheduler(AbstractScheduler):
         Returns:
             str | None: An unique name.
         """
-        args = re.split(" +", command)
+
+        command_list = shlex.split(command)
         # args:
         # ['2', 'python', 'user.py', '--trial_id', '2',
         # '--config', 'config.yaml',
         #  '--x1=3.65996970905703', '--x2=2.99329242098518']
         #
-        trial_id_index = args.index("--trial_id")
-        index_offset = 1
 
-        if trial_id_index is None:
-            return None
+        trial_id = None
+        for arg in command_list:
+            if arg.startswith("--trial_id="):
+                trial_id = arg.split("=")[1]
+                break
 
-        return args[trial_id_index + index_offset]
+        return trial_id
 
     def create_model(self) -> LocalModel:
         """Creates model object of state machine.

--- a/aiaccel/scheduler/local_scheduler.py
+++ b/aiaccel/scheduler/local_scheduler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import shlex
 from typing import Any
 

--- a/aiaccel/scheduler/pylocal_scheduler.py
+++ b/aiaccel/scheduler/pylocal_scheduler.py
@@ -137,16 +137,14 @@ class PylocalScheduler(AbstractScheduler):
 
         commands = ["aiaccel-set-result"]
         for key in args.keys():
-            commands.append("--" + key)
-            commands.append(str(args[key]))
+            commands.append(f"--{key}={str(args[key])}")
 
         commands.append("--objective")
         for y in ys:
             commands.append(str(y))
 
         for key in xs.keys():
-            commands.append("--" + key)
-            commands.append(str(xs[key]))
+            commands.append(f"--{key}={str(xs[key])}")
 
         self.processes.append(Popen(commands))
 

--- a/aiaccel/wrapper_tools.py
+++ b/aiaccel/wrapper_tools.py
@@ -14,7 +14,7 @@ def create_runner_command(
     trial_id: int,
     config_path: str,
     command_error_output: str,
-    enable_command_argument: bool
+    enable_command_argument: bool,
 ) -> list[str]:
     """Create a list of command strings to run a hyper parameter.
 

--- a/aiaccel/wrapper_tools.py
+++ b/aiaccel/wrapper_tools.py
@@ -14,7 +14,7 @@ def create_runner_command(
     trial_id: int,
     config_path: str,
     command_error_output: str,
-    enable_command_argument: bool,
+    enable_name_in_optional_argument: bool,
 ) -> list[str]:
     """Create a list of command strings to run a hyper parameter.
 
@@ -28,7 +28,7 @@ def create_runner_command(
     """
     commands = re.split(" +", command)
     params = param_content["parameters"]
-    if enable_command_argument:
+    if enable_name_in_optional_argument:
         for param in params:
             if "parameter_name" in param.keys() and "value" in param.keys():
                 commands.append(f'--{param["parameter_name"]}={param["value"]}')

--- a/aiaccel/wrapper_tools.py
+++ b/aiaccel/wrapper_tools.py
@@ -9,7 +9,12 @@ from aiaccel.util import create_yaml
 
 
 def create_runner_command(
-    command: str, param_content: dict[str, Any], trial_id: int, config_path: str, command_error_output: str
+    command: str,
+    param_content: dict[str, Any],
+    trial_id: int,
+    config_path: str,
+    command_error_output: str,
+    enable_command_argument: bool
 ) -> list[str]:
     """Create a list of command strings to run a hyper parameter.
 
@@ -23,16 +28,18 @@ def create_runner_command(
     """
     commands = re.split(" +", command)
     params = param_content["parameters"]
-    for param in params:
-        # Fix a bug related a negative exponential parameters
-        # Need to modify wrapper.py as follows:
-        if "parameter_name" in param.keys() and "value" in param.keys():
-            commands.append(f'--{param["parameter_name"]}')
-            commands.append(f'{param["value"]}')
-    commands.append("--trial_id")
-    commands.append(str(trial_id))
-    commands.append("--config")
-    commands.append(config_path)
+    if enable_command_argument:
+        for param in params:
+            if "parameter_name" in param.keys() and "value" in param.keys():
+                commands.append(f'--{param["parameter_name"]}={param["value"]}')
+        commands.append(f"--trial_id={str(trial_id)}")
+        commands.append(f"--config={config_path}")
+    else:
+        for param in params:
+            if "parameter_name" in param.keys() and "value" in param.keys():
+                commands.append(f'{param["value"]}')
+        commands.append(str(trial_id))
+        commands.append(config_path)
     commands.append("2>")
     commands.append(command_error_output)
     return commands

--- a/aiaccel/wrapper_tools.py
+++ b/aiaccel/wrapper_tools.py
@@ -14,7 +14,7 @@ def create_runner_command(
     trial_id: int,
     config_path: str,
     command_error_output: str,
-    enable_name_in_optional_argument: bool,
+    enabled_variable_name_argumentation: bool,
 ) -> list[str]:
     """Create a list of command strings to run a hyper parameter.
 
@@ -28,7 +28,7 @@ def create_runner_command(
     """
     commands = re.split(" +", command)
     params = param_content["parameters"]
-    if enable_name_in_optional_argument:
+    if enabled_variable_name_argumentation:
         for param in params:
             if "parameter_name" in param.keys() and "value" in param.keys():
                 commands.append(f'--{param["parameter_name"]}={param["value"]}')

--- a/examples/benchmark/config.yaml
+++ b/examples/benchmark/config.yaml
@@ -1,9 +1,10 @@
 generic:
   workspace: "./work"
   job_command: "python user.py"
-  # python_file: "./user.py"
-  # function: "main"
+  python_file: "./user.py"
+  function: "main"
   batch_job_timeout: 600
+  enabled_variable_name_argumentation: True
 
 resource:
   type: "abci"

--- a/examples/budget_specified_grid_optimizer/config.yaml
+++ b/examples/budget_specified_grid_optimizer/config.yaml
@@ -2,6 +2,7 @@ generic:
   workspace: "./work"
   job_command: "python user.py"
   batch_job_timeout: 600
+  enabled_variable_name_argumentation: True
 
 resource:
   type: "local"

--- a/examples/resnet50_cifar10/config.yaml
+++ b/examples/resnet50_cifar10/config.yaml
@@ -4,6 +4,7 @@ generic:
   # python_file: "./user.py"
   # function: "main"
   batch_job_timeout: 7200
+  enabled_variable_name_argumentation: True
 
 resource:
   type: "abci"

--- a/examples/schwefel/config.yaml
+++ b/examples/schwefel/config.yaml
@@ -4,6 +4,7 @@ generic:
   # python_file: "./user.py"
   # function: "main"
   batch_job_timeout: 600
+  enabled_variable_name_argumentation: True
 
 resource:
   # type: "abci"

--- a/examples/sphere/config.yaml
+++ b/examples/sphere/config.yaml
@@ -4,6 +4,7 @@ generic:
   # python_file: "./user.py"
   # function: "main"
   batch_job_timeout: 600
+  enabled_variable_name_argumentation: True
 
 resource:
   # type: "abci"

--- a/tests/unit/abci_test/test_abci_batch.py
+++ b/tests/unit/abci_test/test_abci_batch.py
@@ -24,7 +24,7 @@ class TestCreateAbciBatchFile(BaseTest):
         dict_lock = work_dir.joinpath('lock')
         batch_file = work_dir.joinpath('runner', 'run_test.sh')
         command = config.generic.job_command
-        enable_name_in_optional_argument = config.generic.enable_name_in_optional_argument
+        enabled_variable_name_argumentation = config.generic.enabled_variable_name_argumentation
         trial_id = 99
 
         output_file_path = work_dir.joinpath('result', f'{trial_id}.yml')
@@ -41,7 +41,7 @@ class TestCreateAbciBatchFile(BaseTest):
             batch_file,
             job_script_preamble,
             command,
-            enable_name_in_optional_argument,
+            enabled_variable_name_argumentation,
             dict_lock
         )
         assert work_dir.joinpath('runner/run_test.sh').exists()

--- a/tests/unit/abci_test/test_abci_batch.py
+++ b/tests/unit/abci_test/test_abci_batch.py
@@ -24,6 +24,7 @@ class TestCreateAbciBatchFile(BaseTest):
         dict_lock = work_dir.joinpath('lock')
         batch_file = work_dir.joinpath('runner', 'run_test.sh')
         command = config.generic.job_command
+        enable_command_argument = config.generic.enable_command_argument
         trial_id = 99
 
         output_file_path = work_dir.joinpath('result', f'{trial_id}.yml')
@@ -40,6 +41,7 @@ class TestCreateAbciBatchFile(BaseTest):
             batch_file,
             job_script_preamble,
             command,
+            enable_command_argument,
             dict_lock
         )
         assert work_dir.joinpath('runner/run_test.sh').exists()

--- a/tests/unit/abci_test/test_abci_batch.py
+++ b/tests/unit/abci_test/test_abci_batch.py
@@ -24,7 +24,7 @@ class TestCreateAbciBatchFile(BaseTest):
         dict_lock = work_dir.joinpath('lock')
         batch_file = work_dir.joinpath('runner', 'run_test.sh')
         command = config.generic.job_command
-        enable_command_argument = config.generic.enable_command_argument
+        enable_name_in_optional_argument = config.generic.enable_name_in_optional_argument
         trial_id = 99
 
         output_file_path = work_dir.joinpath('result', f'{trial_id}.yml')
@@ -41,7 +41,7 @@ class TestCreateAbciBatchFile(BaseTest):
             batch_file,
             job_script_preamble,
             command,
-            enable_command_argument,
+            enable_name_in_optional_argument,
             dict_lock
         )
         assert work_dir.joinpath('runner/run_test.sh').exists()

--- a/tests/unit/scheduler_test/job_test/test_job_thread.py
+++ b/tests/unit/scheduler_test/job_test/test_job_thread.py
@@ -5,12 +5,18 @@ from subprocess import Popen
 
 import pytest
 
-from aiaccel.common import (dict_hp_finished, dict_hp_ready, dict_hp_running,
-                            dict_lock, dict_result, dict_runner, goal_maximize,
-                            goal_minimize)
+from aiaccel.common import (
+    dict_hp_finished,
+    dict_hp_ready,
+    dict_hp_running,
+    dict_lock,
+    dict_result,
+    dict_runner,
+    goal_maximize,
+    goal_minimize,
+)
 from aiaccel.config import ResourceType
-from aiaccel.scheduler import (AbciModel, CustomMachine, Job, LocalModel,
-                               LocalScheduler, create_scheduler)
+from aiaccel.scheduler import AbciModel, CustomMachine, Job, LocalModel, LocalScheduler, create_scheduler
 from aiaccel.util.process import OutputHandler
 from tests.base_test import BaseTest
 
@@ -265,7 +271,7 @@ class TestModel(BaseTest):
         # self.job.scheduler.stats.append({'name': '001'})
         # self.job.scheduler.stats.append({'name': 0})
         self.job.scheduler.stats.append(
-            {'name': '2 python user.py --trial_id 0 --config config.yaml --x1=1.0 --x2=1.0'}
+            {'name': '2 python user.py --trial_id=0 --config=config.yaml --x1=1.0 --x2=1.0'}
         )
         assert not self.model.conditions_kill_confirmed(self.job)
 

--- a/tests/unit/scheduler_test/test_local_scheduler.py
+++ b/tests/unit/scheduler_test/test_local_scheduler.py
@@ -1,6 +1,4 @@
-from aiaccel.scheduler import Job
-from aiaccel.scheduler import LocalScheduler
-
+from aiaccel.scheduler import Job, LocalScheduler
 from tests.base_test import BaseTest
 
 
@@ -32,6 +30,6 @@ class TestLocalScheduler(BaseTest):
         database_remove()
         config = self.load_config_for_test(self.configs['config.json'])
         scheduler = LocalScheduler(config)
-        s = {"name": "2 python user.py --trial_id 5 --config config.yaml --x1=1.0 --x2=1.0"}
+        s = {"name": "2 python user.py --trial_id=5 --config=config.yaml --x1=1.0 --x2=1.0"}
         trial_id = int(scheduler.parse_trial_id(s['name']))
         assert trial_id == 5

--- a/tests/unit/test_wrapper_tools.py
+++ b/tests/unit/test_wrapper_tools.py
@@ -37,15 +37,12 @@ class TestCeaterRunnerComand(BaseTest):
         print(commands)
         assert commands[0] == 'python'
         assert commands[1] == 'original_main.py'
-        assert commands[2] == '--x1'
-        assert commands[3] == '0.9932890709584586'
+        assert commands[2] == '--x1=0.9932890709584586'
         # skip --x2 ~ x10
-        assert commands[22] == '--trial_id'
-        assert commands[23] == 'name'
-        assert commands[24] == '--config'
-        assert commands[25] == 'config.json'
-        assert commands[26] == '2>'
-        assert commands[27] == error_output
+        assert commands[12] == '--trial_id=name'
+        assert commands[13] == '--config=config.json'
+        assert commands[14] == '2>'
+        assert commands[15] == error_output
 
         start_time = datetime.now().strftime(datetime_format)
         end_time = datetime.now().strftime(datetime_format)

--- a/tests/unit/test_wrapper_tools.py
+++ b/tests/unit/test_wrapper_tools.py
@@ -31,7 +31,8 @@ class TestCeaterRunnerComand(BaseTest):
             get_one_parameter(),
             'name',
             'config.json',
-            error_output
+            error_output,
+            True
         )
         print(commands)
         assert commands[0] == 'python'


### PR DESCRIPTION
- 負の数のオプショナル引数に関する問題を修正しました．

aiaccelが生成するコマンドは，オプショナル引数は次のように生成されます．
~~~
--x0 -1e-3
~~~
しかしながら，parser_argumentではこのような指定方法はエラーになります．

エラーを回避するには，次のように指定する必要があります．
~~~
--x0=-1e-3
~~~
このプルリクエストでは，すべてのコマンドライン引数を，`<name>=<value>`で指定するように変更しました．

<br>
<hr>
<br>

- オプショナル引数に，変数名を含む or 含まないを変更するパラメータを追加しました．
~~~
enable_name_in_optional_argument: true
~~~
~~~
enable_name_in_optional_argument: false
~~~
デフォルトは true で機能します．
この機能は，最適化の対象が，pythonプログラム以外のユーザープログラムの場合を想定した改修です．