### PR TITLE
Move decode().strip() in OutputHandler class.

### DIFF
--- a/aiaccel/util/process.py
+++ b/aiaccel/util/process.py
@@ -134,21 +134,19 @@ class OutputHandler(threading.Thread):
             None
         """
         self._start_time = datetime.datetime.now()
-        self._stdouts = []
-        self._stderrs = []
 
         while True:
             if self._proc.stdout is None:
                 break
 
-            stdout = self._proc.stdout.readline().decode().strip()
+            stdout = self._proc.stdout.readline()
             if stdout:
-                self._stdouts.append(stdout)
+                self._stdouts.append(stdout.decode().strip())
 
             if self._proc.stderr is not None:
-                stderr = self._proc.stderr.readline().decode().strip()
+                stderr = self._proc.stderr.readline()
                 if stderr:
-                    self._stderrs.append(stderr)
+                    self._stderrs.append(stderr.decode().strip())
             else:
                 stderr = None
 


### PR DESCRIPTION
type = "local" の場合に、ユーザプログラムが標準出力に空行のみを入力（例えば、print("")のようなコード）した際に、aiaccel/util/process.py の OutputHandler がその標準出力を受け取ると、その時点で OutputHandler が停止することがある現象を修正しました。

- 修正前のコードでは、stdout変数に標準出力を改行コードを除いた状態で代入しており、その結果 OutputHandler のwhileループ終了判定を行う if 文が、空行のみを読み込んだ場合にも True になることが起きていました。
https://github.com/aistairc/aiaccel/blob/ffb81ca72157110b938ec0aae17085be90205de1/aiaccel/util/process.py#L155-L156

- 修正版のコードでは、stdout変数には標準出力を改行コードが残る状態で代入し、改行コードを取り除く処理( `decode().strip()` )をリストにappendするタイミングにずらしました。

close #304 