### PR TITLE
Optuna>=3.4.0

### DIFF
--- a/aiaccel/optimizer/motpe_optimizer.py
+++ b/aiaccel/optimizer/motpe_optimizer.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import optuna
 from omegaconf.dictconfig import DictConfig
 
-from aiaccel.optimizer.tpe_optimizer import TpeOptimizer, TPESamplerWrapper
+from aiaccel.optimizer.tpe_optimizer import (
+    LazyRandomStateWrapper,
+    RandomSamplerWrapper,
+    TpeOptimizer,
+    TPESamplerWrapper,
+)
 
 
 class MOTpeOptimizer(TpeOptimizer):
@@ -30,8 +35,8 @@ class MOTpeOptimizer(TpeOptimizer):
         """
 
         sampler = TPESamplerWrapper()
-        sampler._rng = self._rng
-        sampler._random_sampler._rng = self._rng
+        sampler._rng = LazyRandomStateWrapper(rng=self._rng)
+        sampler._random_sampler = RandomSamplerWrapper(rng=self._rng)
         storage_path = str(f"sqlite:///{self.workspace.path}/optuna-{self.study_name}.db")
         storage = optuna.storages.RDBStorage(url=storage_path)
         load_if_exists = self.config.resume is not None

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -23,11 +23,13 @@ from aiaccel.parameter import (
 
 class LazyRandomStateWrapper(LazyRandomState):
     def __init__(self, rng: numpy.random.RandomState | None = None) -> None:
+        super().__init__()
         self._rng = rng
 
 
 class RandomSamplerWrapper(RandomSampler):
     def __init__(self, rng: numpy.random.RandomState | None = None) -> None:
+        super().__init__()
         self._rng = LazyRandomStateWrapper(rng)
 
 

--- a/aiaccel/optimizer/tpe_optimizer.py
+++ b/aiaccel/optimizer/tpe_optimizer.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy
 import optuna
 import sqlalchemy
 import sqlalchemy.orm as sqlalchemy_orm
 from omegaconf.dictconfig import DictConfig
+from optuna.samplers._lazy_random_state import LazyRandomState
+from optuna.samplers._random import RandomSampler
 from optuna.storages._rdb import models
 
 from aiaccel.optimizer import AbstractOptimizer
@@ -16,6 +19,16 @@ from aiaccel.parameter import (
     IntParameter,
     OrdinalParameter,
 )
+
+
+class LazyRandomStateWrapper(LazyRandomState):
+    def __init__(self, rng: numpy.random.RandomState | None = None) -> None:
+        self._rng = rng
+
+
+class RandomSamplerWrapper(RandomSampler):
+    def __init__(self, rng: numpy.random.RandomState | None = None) -> None:
+        self._rng = LazyRandomStateWrapper(rng)
 
 
 class TPESamplerWrapper(optuna.samplers.TPESampler):
@@ -186,8 +199,8 @@ class TpeOptimizer(AbstractOptimizer):
         """
 
         sampler = TPESamplerWrapper()
-        sampler._rng = self._rng
-        sampler._random_sampler._rng = self._rng
+        sampler._rng = LazyRandomStateWrapper(rng=self._rng)
+        sampler._random_sampler = RandomSamplerWrapper(rng=self._rng)
         storage_path = str(f"sqlite:///{self.workspace.path}/optuna-{self.study_name}.db")
         storage = optuna.storages.RDBStorage(url=storage_path)
         load_if_exists = self.config.resume is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "fasteners>=0.18,<1.0.0",
     "numpy",
     "omegaconf",
-    "optuna>=3.1.0,<4.0.0",
+    "optuna>=3.4.0,<4.0.0",
     "psutil",
     "scipy>=1.10.1,<2.0.0",
     "sqlalchemy>=2.0.7,<3.0.0",


### PR DESCRIPTION
Optuna で、 TPESampler の _rng オブジェクトが、numpy.ramdom.RandomState から LazyRandomState に変更になった影響で、aiaccel の TPE が動作しなくなった問題を修正。