### PR TITLE
fix shrink in nelder_mead

### DIFF
--- a/aiaccel/optimizer/_nelder_mead.py
+++ b/aiaccel/optimizer/_nelder_mead.py
@@ -191,7 +191,7 @@ class NelderMead:
         self.store = Store()
         self.waits = {
             "initialize": self.simplex.n_dim + 1,
-            "shrink": self.simplex.n_dim + 1,
+            "shrink": self.simplex.n_dim,
             "expand": 1,
             "inside_contract": 1,
             "outside_contract": 1,
@@ -337,7 +337,7 @@ class NelderMead:
         elif self.state == "shrink":
             xs = self.shrink()
             self.change_state("shrink_pending")
-            return xs
+            return xs[1:]
 
         elif self.state == "shrink_pending":
             return []


### PR DESCRIPTION
nelder_mead の shrink 時に、（探索済みのため）本来計算する必要のない simplex の最適点も再計算してしまう現象を修正しました。

https://github.com/aistairc/aiaccel/blob/255190dbeaffaa472c21038d1ac70ec62863dc09/aiaccel/optimizer/_nelder_mead.py#L194

- 計算する必要のある点の数を self.simplex.n_dim (= self.waits["initialize"] - 1) に修正しました。

https://github.com/aistairc/aiaccel/blob/255190dbeaffaa472c21038d1ac70ec62863dc09/aiaccel/optimizer/_nelder_mead.py#L340

- shrink時に計算する点群を返す箇所から、最適点 (xs[0])を除外しました。

修正前の result.csv

```
trial_id,x1,x2,objective
000000,1.5085575146283974,3.9415689003655507,[10.739530922131664]
000001,4.877415968455842,0.9251026408128193,[10.57145405611417]
000002,4.3466264063373075,0.5427652493513835,[11.489534067028274]
000003,2.0393470767469317,4.323906291826987,[11.248221876356672]
000004,2.6161669091445257,3.3786210312080858,[11.309308653564921]
000005,4.877415968455842,0.9251026408128193,[10.57145405611417]
000006,3.1929867415421196,2.433335770589185,[10.627479029859607]
000007,4.612021187396575,0.7339339450821014,[11.736365481207121]
000008,3.4583815226013854,2.624504466319903,[11.461679290503543]
000009,3.746791438800183,2.1518618360104527,[10.540753902999715]
```

- trial ID 000005 付近でshrinkが発生し、 trial ID 000001, 000005 で同じ点を計算しています。

修正後の result.csv

```
trial_id,x1,x2,objective
000000,1.5085575146283974,3.9415689003655507,[10.739530922131664]
000001,4.877415968455842,0.9251026408128193,[10.57145405611417]
000002,4.3466264063373075,0.5427652493513835,[11.489534067028274]
000003,2.0393470767469317,4.323906291826987,[11.248221876356672]
000004,2.6161669091445257,3.3786210312080858,[11.309308653564921]
000005,3.1929867415421196,2.433335770589185,[10.627479029859607]
000006,4.612021187396575,0.7339339450821014,[11.736365481207121]
000007,3.4583815226013854,2.624504466319903,[11.461679290503543]
000008,3.746791438800183,2.1518618360104527,[10.540753902999715]
000009,5.431220665713905,0.6436287062340869,[13.024197195076397]
```

- 同じ初期点・関数で実行していますが、 trial ID 000005 での同じ点の計算が消えました。
- また修正前の 000006 ~ 000009 と修正後の 000005 ~ 000008 までの点群の結果が一致していることから、重複した点の計算が消えた以外に挙動に差異が無いことを確認しました。
