### PR TITLE
fix aiaccel-report

### DIFF
--- a/aiaccel/cli/report.py
+++ b/aiaccel/cli/report.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from logging import StreamHandler, getLogger
 
 from aiaccel.cli import CsvWriter
+from aiaccel.config import load_config
 
 logger = getLogger(__name__)
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))
@@ -14,8 +15,9 @@ def main() -> None:  # pragma: no cover
     parser = ArgumentParser()
     parser.add_argument("--config", "-c", type=str, default="config.yml")
     args = parser.parse_args()
+    config = load_config(args.config)
 
-    csv_writer = CsvWriter(args.config)
+    csv_writer = CsvWriter(config)
     csv_writer.create()
 
 


### PR DESCRIPTION
aiaccel-report が下記エラーで停止して実行できない現象を修正しました。

```
$ aiaccel-report --config config.yaml
Traceback (most recent call last):
  File "/home/member/hpopt/main/work/bin/aiaccel-report", line 8, in <module>
    sys.exit(main())
  File "/home/member/hpopt/main/work/lib/python3.8/site-packages/aiaccel/cli/report.py", line 19, in main
    csv_writer = CsvWriter(args.config)
  File "/home/member/hpopt/main/work/lib/python3.8/site-packages/aiaccel/cli/csv_writer.py", line 34, in __init__
    self.workspace = Workspace(self.config.generic.workspace)
AttributeError: 'str' object has no attribute 'generic'
```

- config の読み込み形式が古いままだったのが原因だったので、 cli/start.py を参考に現在の読み込み形式に修正しました。