### PR TITLE
Fixed a problem where results were sometimes not written to the database.

### DIFF
--- a/aiaccel/manager/job/model/local_model.py
+++ b/aiaccel/manager/job/model/local_model.py
@@ -36,6 +36,8 @@ class LocalModel(AbstractModel):
             return True
         if obj.th_oh.get_returncode() is None or self.is_firsttime_called:
             return False
+        elif obj.th_oh.is_alive():
+            return False
         else:
             self.write_results_to_database(obj)
             self.is_firsttime_called = True


### PR DESCRIPTION
ローカル実行時にデータベースに最適化結果(objective)が書き込まれないことがある現象を修正しました。

- 現状のaiaccel 8b18a4f96a5c194cd72707fbf1320aa58457755d では、OutputHandler がユーザプログラムの標準出力を読み取り、LocalModel 内の write_results_to_database 関数で OutputHandler から標準出力を受け取り、objective をデータベースに書き込む処理を実行しています。
https://github.com/aistairc/aiaccel/blob/8b18a4f96a5c194cd72707fbf1320aa58457755d/aiaccel/util/process.py#L50
https://github.com/aistairc/aiaccel/blob/8b18a4f96a5c194cd72707fbf1320aa58457755d/aiaccel/manager/job/model/local_model.py#L90
  - しかし、OutputHandler が標準出力を読み取り終えるより前に、write_results_to_database 関数が実行されることが有ります。
  - 具体的には、ユーザプログラムが大量の標準出力を出力した際に、 OutputHandler が標準出力を読み終える前に write_results_to_database が呼ばれ、途中の適当な標準出力を objective として扱い、floatへの変換に失敗して何も書き込まれないようなことが発生します。(#312 に関連)
- そのようなことを防ぐために、`elif obj.th_oh.is_alive():` を追加して OutputHandler が落ちるまでは write_results_to_database 関数が実行されないように改修しました。