### PR TITLE
Fixed a problem with neldermead sometimes searching for out-of-range coordinates.

### DIFF
--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -49,14 +49,13 @@ class NelderMeadOptimizer(AbstractOptimizer):
     def convert_ndarray_to_parameter(self, ndarray: np.ndarray[Any, Any]) -> list[dict[str, float | int | str]]:
         """Convert a list of numpy.ndarray to a list of parameters."""
         new_params = copy.deepcopy(self.base_params)
-        for name, value, b in zip(self.param_names, ndarray, self.bdrys):
-            for new_param in new_params:
-                if new_param["parameter_name"] == name:
-                    new_param["value"] = value
-                if b[0] <= value <= b[1]:
-                    new_param["out_of_boundary"] = False
-                else:
-                    new_param["out_of_boundary"] = True
+        for name, value, b, new_param in zip(self.param_names, ndarray, self.bdrys, new_params):
+            if new_param["parameter_name"] == name:
+                new_param["value"] = value
+            if b[0] <= value <= b[1]:
+                new_param["out_of_boundary"] = False
+            else:
+                new_param["out_of_boundary"] = True
         return new_params
 
     def new_finished(self) -> list[int]:

--- a/aiaccel/optimizer/nelder_mead_optimizer.py
+++ b/aiaccel/optimizer/nelder_mead_optimizer.py
@@ -49,9 +49,11 @@ class NelderMeadOptimizer(AbstractOptimizer):
     def convert_ndarray_to_parameter(self, ndarray: np.ndarray[Any, Any]) -> list[dict[str, float | int | str]]:
         """Convert a list of numpy.ndarray to a list of parameters."""
         new_params = copy.deepcopy(self.base_params)
-        for name, value, b, new_param in zip(self.param_names, ndarray, self.bdrys, new_params):
-            if new_param["parameter_name"] == name:
-                new_param["value"] = value
+        for name, value in zip(self.param_names, ndarray):
+            for new_param in new_params:
+                if new_param["parameter_name"] == name:
+                    new_param["value"] = value
+        for value, b, new_param in zip(ndarray, self.bdrys, new_params):
             if b[0] <= value <= b[1]:
                 new_param["out_of_boundary"] = False
             else:


### PR DESCRIPTION
neldermead で範囲外の座標の計算結果をinfとして扱わず、通常通り計算を行う場合が現象を修正しました。

- 座標が範囲外かどうかを判定する箇所で、n(=ハイパパラメータの個数)回ループを回せば十分なところを、n^n回ループを回していました。
  - これによりフラグ変数 `new_param["out_of_boundary"]` の上書きが発生しており、最後のハイパパラメータの座標が範囲内に入っているかどうかのみを判定しています。
  - 例えば 0< x1 < 5, 0< x2 < 5 の範囲設定で、x1 = -1, x2 = 2 だった場合、x1が範囲外ですが無視されて、x2が範囲内なので通常通り計算する処理が適用されます。
https://github.com/aistairc/aiaccel/blob/12aad568cfa4c04327a78a3bddbe02d9b661f6e2/aiaccel/optimizer/nelder_mead_optimizer.py#L52-L59
- 座標が範囲外かどうかを判定する箇所を、別のn回ループとして書き直して、正常に範囲外の処理が実行されるように修正しました。

close #335 