### PR TITLE
fixed typo in aiaccel/examples/resnet50_cifar10

### DIFF
--- a/examples/resnet50_cifar10/job_script_preamble.sh
+++ b/examples/resnet50_cifar10/job_script_preamble.sh
@@ -5,5 +5,5 @@
 #$ -l h_rt=2:00:00
 
 source /etc/profile.d/modules.sh
-module load gcc/11.2.0 python/3.8/3.8.13 cuda/10.1/10.1.243 cudnn/7.6/7.6.5
+module load gcc/8.5.0 python/3.10 cuda/11.8 cudnn/8.7
 source ~/optenv/bin/activate

--- a/examples/resnet50_cifar10/user.py
+++ b/examples/resnet50_cifar10/user.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import torch.nn as nn
 import torch.optim as optim
-from torch.optim.lr_manager import CosineAnnealingLR
+from torch.optim.lr_scheduler import CosineAnnealingLR
 from torchvision import datasets, models, transforms
 
 from aiaccel.util import aiaccel


### PR DESCRIPTION
- resnetプログラムのuser.py中のタイポを修正．
- 現行ABCIのmoduleのリストに合わせてjob_script_preamble.shの module load の記述を更新．