### PR TITLE
Update ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ line-length = 120
 target-version = "py310"
 fix = true
 
-select = ["E", "F", "W", "UP", "B", "SIM", "I", "C"]
+[tool.ruff.lint]
+select = ["F", "E", "W", "UP", "B", "SIM", "I", "C", "A", "ERA", "N"]
 
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,5 @@ target-version = "py310"
 fix = true
 
 [tool.ruff.lint]
-select = ["F", "E", "W", "UP", "B", "SIM", "I", "C", "A", "ERA", "N"]
+select = ["F", "E", "W", "UP", "B", "SIM", "I", "C", "A", "ERA", "N", "C90"]
 


### PR DESCRIPTION
closes #287 

flake8-expression-complexity
flake8-cognitive-complexty
こちら反映できてないですが，代わりにC90 (https://docs.astral.sh/ruff/rules/#mccabe-c90) が入っています．