### PR TITLE
Add the actions to generate docs for GitHub Pages.

### DIFF
--- a/.github/workflows/publish_pages.yaml
+++ b/.github/workflows/publish_pages.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v2
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish_pages.yaml
+++ b/.github/workflows/publish_pages.yaml
@@ -24,7 +24,7 @@ jobs:
           sphinx-build docs/source/ _build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/feature/gh-pages' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_pages.yaml
+++ b/.github/workflows/publish_pages.yaml
@@ -1,0 +1,32 @@
+name: Publish on GitHub Pages
+
+on:
+  [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev,github-actions,test]
+      - name: Sphinx build
+        run: |
+          sphinx-apidoc -f -o docs/source/ ./aiaccel
+      - name: Sphinx build
+        run: |
+          sphinx-build docs/source/ _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build
+          force_orphan: true

--- a/.github/workflows/publish_pages.yaml
+++ b/.github/workflows/publish_pages.yaml
@@ -24,7 +24,7 @@ jobs:
           sphinx-build docs/source/ _build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/feature/gh-pages' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_pages.yaml
+++ b/.github/workflows/publish_pages.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,18 +10,20 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
 import sys
-sys.path.insert(0, os.path.abspath('../../'))
+from pathlib import Path
+
+root_path = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(root_path.absolute()))
 
 # -- Project information -----------------------------------------------------
 
-project = 'aiaccel'
-copyright = '2022, AIST'
-author = 'AIST'
+project = "aiaccel"
+copyright = "2024, AIST"
+author = "AIST"
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = "1.0.0"
 
 
 # -- General configuration ---------------------------------------------------
@@ -30,44 +32,46 @@ release = '0.0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.todo',
-    'sphinx_fontawesome',
-    'sphinx_rtd_theme',
-    'myst_parser',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    "sphinx_fontawesome",
+    "sphinx_rtd_theme",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    '_build',
-    'Thumbs.db',
-    '.DS_Store',
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
 ]
 
 # Add optional syntaxes for MyST-Parser which are disabled by default.
-myst_enable_extensions = [
-    # "amsmath",
-    # "attrs_inline",
-    # "colon_fence",
-    # "deflist",
-    "dollarmath",
-    # "fieldlist",
-    # "html_admonition",
-    # "html_image",
-    # "inv_link",
-    # "linkify",
-    # "replacements",
-    # "smartquotes",
-    # "strikethrough",
-    # "substitution",
-    # "tasklist",
-]
+# myst_enable_extensions = [
+# "amsmath",
+# "attrs_inline",
+# "colon_fence",
+# "deflist",
+# "dollarmath",
+# "fieldlist",
+# "html_admonition",
+# "html_image",
+# "inv_link",
+# "linkify",
+# "replacements",
+# "smartquotes",
+# "strikethrough",
+# "substitution",
+# "tasklist",
+# ]
 
 # Auto-generated header anchors
 # The MyST Parser can automatically generate label “slugs” for header anchors
@@ -76,16 +80,20 @@ myst_enable_extensions = [
 # [](path/to/file.md#header-anchor). To achieve this, use the
 # myst_heading_anchors = DEPTH configuration option, where DEPTH is the depth
 # of header levels for which you wish to generate links.
-myst_heading_anchors = 3
+# myst_heading_anchors = 3
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 html_show_sourcelink = False
 html_show_sphinx = False
+html_static_path = ["_static"]
+html_sidebars = {"**": ["search-field", "sidebar-nav-bs", "sidebar-ethical-ads"]}
+source_suffix = {".rst": "restructuredtext", ".txt": "markdown", ".md": "markdown"}
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -93,8 +101,8 @@ html_show_sphinx = False
 # html_static_path = ['_static']
 
 gettext_compact = False
-locale_dirs = ['locale/']
-language = 'ja'
+locale_dirs = ["locale/"]
+language = "ja"
 
 # -- Extension configuration -------------------------------------------------
 todo_include_todos = True


### PR DESCRIPTION
Add the GitHub Actions to generate the documentations for GitHub Pages.
This update don't force developers to generate the sphinx documents on local computer.
The actions generate the documents and upload the documents to gh-pages branch.
The generated files can be shown on GitHub Pages.