### PR TITLE
Replace the badge from readthedocs to publishing on github pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # aiaccel: an HPO library for ABCI
 [![GitHub license](https://img.shields.io/github/license/aistairc/aiaccel.svg)](https://github.com/aistairc/aiaccel)
 [![Supported Python version](https://img.shields.io/badge/Python-3.8-blue)](https://github.com/aistairc/aiaccel)
-[![Documentation Status](https://readthedocs.org/projects/aiaccel/badge/?version=latest)](https://aiaccel.readthedocs.io/en/latest/)
+[![Publish on GitHub Pages](https://github.com/aistairc/aiaccel/actions/workflows/publish_pages.yaml/badge.svg)](https://github.com/aistairc/aiaccel/actions/workflows/publish_pages.yaml)
 ![CI status](https://github.com/aistairc/aiaccel/actions/workflows/actions.yaml/badge.svg)
 
 [**日本語  (Japanese)**](https://github.com/aistairc/aiaccel/blob/main/README_JP.md)

--- a/README_JP.md
+++ b/README_JP.md
@@ -3,7 +3,7 @@
 # aiaccel: an HPO library for ABCI
 [![GitHub license](https://img.shields.io/github/license/aistairc/aiaccel.svg)](https://github.com/aistairc/aiaccel)
 [![Supported Python version](https://img.shields.io/badge/Python-3.8-blue)](https://github.com/aistairc/aiaccel)
-[![Documentation Status](https://readthedocs.org/projects/aiaccel/badge/?version=latest)](https://aiaccel.readthedocs.io/ja/latest/)
+[![Publish on GitHub Pages](https://github.com/aistairc/aiaccel/actions/workflows/publish_pages.yaml/badge.svg)](https://github.com/aistairc/aiaccel/actions/workflows/publish_pages.yaml)
 ![CI status](https://github.com/aistairc/aiaccel/actions/workflows/actions.yaml/badge.svg)
 
 


### PR DESCRIPTION
- Remove readthedocs badge.
- Add github actions badge of publishing github pages.