### PR TITLE
Feature/v2 partial fixed sampler

### DIFF
--- a/aiaccel/apps/optimize.py
+++ b/aiaccel/apps/optimize.py
@@ -9,6 +9,7 @@ from hydra.utils import instantiate
 from omegaconf import OmegaConf as oc  # noqa: N813
 
 from optuna.trial import Trial
+from optuna.samplers import PartialFixedSampler
 
 from aiaccel.hpo.optuna.suggest_wrapper import Const, Suggest, SuggestFloat, T
 from aiaccel.job import AbciJobExecutor, BaseJobExecutor, LocalJobExecutor
@@ -48,6 +49,13 @@ n_max_jobs: 4
 
 group: gaa50000
 
+additional_scenario:  # Optional
+  - n_trials: 30
+    n_max_jobs: 4
+    fixed_params:
+      params: ["x1"]
+
+
 """
 
 
@@ -66,6 +74,12 @@ class HparamsManager:
 
     def suggest_hparams(self, trial: Trial) -> dict[str, float | int | str | list[float | int | str]]:
         return {name: param_fn(trial) for name, param_fn in self.params.items()}
+
+    def update_fixed_params(self, sampler) -> None:
+        """Update parameters based on the sampler's fixed parameters"""
+        if hasattr(sampler, 'fixed_params'):
+            for name, value in sampler.fixed_params.items():
+                self.params[name] = Const(name=name, value=value)
 
 
 def main() -> None:
@@ -115,8 +129,45 @@ def main() -> None:
                 y = pkl.load(f)
 
             study.tell(trial, y)
+            print(f"Trial {trial.number} finished with value {y}, params: {trial.params}")
 
             finished_job_count += 1
+
+    if "additional_scenario" in config:
+        print("Additional scenarios detected. Running additional scenarios.")
+        for scenario in config.additional_scenario:
+            fixed_params = {}
+            if "params" in scenario.get("fixed_params", {}):
+                for param in scenario["fixed_params"]["params"]:
+                    fixed_params[param] = study.best_params[param]
+            if "values" in scenario.get("fixed_params", {}):
+                fixed_params.update(scenario["fixed_params"]["values"])
+            if fixed_params:
+                base_sampler = instantiate(config.study.sampler)
+                study.sampler = PartialFixedSampler(
+                    fixed_params=fixed_params,
+                    base_sampler=base_sampler
+                )
+                params.update_fixed_params(study.sampler)
+            finished_job_count = 0
+            while finished_job_count < scenario["n_trials"]:
+                n_running_jobs = len(jobs.get_running_jobs())
+                n_max_jobs = min(jobs.available_slots(), scenario["n_trials"] - finished_job_count - n_running_jobs)
+                for _ in range(n_max_jobs):
+                    trial = study.ask()
+                    hparams = params.suggest_hparams(trial)
+                    jobs.job_name = str(jobs.job_filename) + f"_{trial.number}"
+                    job = jobs.submit(
+                        args=[result_filename_template] + sum([[f"--{k}", f"{v:.5f}"] for k, v in hparams.items()], []),
+                        tag=trial,
+                    )
+                for job in jobs.collect_finished():
+                    trial = job.tag
+                    with open(result_filename_template.format(job=job), "rb") as f:
+                        y = pkl.load(f)
+                    study.tell(trial, y)
+                    print(f"Trial {trial.number} finished with value {y}, params: {trial.params}")
+                    finished_job_count += 1
 
 
 if __name__ == "__main__":

--- a/examples/job/optuna/PartialFixed/config.yaml
+++ b/examples/job/optuna/PartialFixed/config.yaml
@@ -1,0 +1,28 @@
+study:
+  _target_: optuna.create_study
+  direction: minimize
+
+  sampler:
+    _target_: optuna.samplers.TPESampler
+    seed: 0
+
+params:
+  _convert_: partial
+  _target_: aiaccel.apps.optimize.HparamsManager
+  x1: [-1, 1]
+  x2: [-1, 1]
+
+n_trials: 10
+n_max_jobs: 1
+group: gaa50000
+
+additional_scenario:
+  - n_trials: 10
+    n_max_jobs: 1
+    fixed_params:
+      params: ["x2"]
+
+  # - n_trials: 10
+  #   n_max_jobs: 1
+  #   fixed_params:
+  #     params: ["x1"]

--- a/examples/job/optuna/PartialFixed/objective.py
+++ b/examples/job/optuna/PartialFixed/objective.py
@@ -1,0 +1,23 @@
+import pickle as pkl
+
+from argparse import ArgumentParser
+from pathlib import Path
+import numpy as np
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("dst_filename", type=Path)
+    parser.add_argument("--x1", type=float)
+    parser.add_argument("--x2", type=float)
+    args = parser.parse_args()
+
+    x1, x2 = args.x1, args.x2
+
+    y = x1**2 + x2
+
+    with open(args.dst_filename, "wb") as f:
+        pkl.dump(y, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/job/optuna/PartialFixed/objective.sh
+++ b/examples/job/optuna/PartialFixed/objective.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#$-l rt_C.small=1
+#$-cwd
+
+source /etc/profile.d/modules.sh
+module load gcc/13.2.0
+module load python/3.10/3.10.14
+
+python objective.py $@

--- a/examples/job/optuna/config.yaml
+++ b/examples/job/optuna/config.yaml
@@ -18,5 +18,10 @@ params:
 
 n_trials: 30
 n_max_jobs: 4
-
 group: gaa50000
+
+additional_scenario:
+  - n_trials: 30
+    n_max_jobs: 4
+    fixed_params:
+      params: ["x1"]

--- a/examples/job/optuna/config.yaml
+++ b/examples/job/optuna/config.yaml
@@ -12,6 +12,7 @@ params:
   x1: [0, 1]
   x2:
     _target_: aiaccel.apps.optimize.SuggestFloat
+    name: x2
     low: 0.0
     high: 1.0
     log: false
@@ -19,9 +20,3 @@ params:
 n_trials: 30
 n_max_jobs: 4
 group: gaa50000
-
-additional_scenario:
-  - n_trials: 30
-    n_max_jobs: 4
-    fixed_params:
-      params: ["x1"]


### PR DESCRIPTION
## Optuna の  `PartialFixedSampler` を aiaccel で実行するための実装のたたき台.


- 追加の実行部分は、config に `additional_scenario` で追加する
``` yaml
study:
  _target_: optuna.create_study
  direction: minimize

  sampler:
    _target_: optuna.samplers.TPESampler
    seed: 0

params:
  _convert_: partial
  _target_: aiaccel.apps.optimize.HparamsManager
  x1: [-1, 1]
  x2: [-1, 1]

n_trials: 20
n_max_jobs: 1
group: gaa50000

additional_scenario:  # 新規機能
  - n_trials: 15
    n_max_jobs: 1
    fixed_params:
      params: ["x1"]

  - n_trials: 15
     n_max_jobs: 1
     fixed_params:
       params: ["x2"]
```

- この例では、TPE を 20 回試行したのち、x1の値をベストパラメータ値で固定し、再度TPEで15回の試行を行う。その後、x2の値をベストパラメータ値で固定し、再度15回の試行を行う。

- additional_scenario には、追加の最適化シナリオを無制限に設定できる。

- 開発会議では、追加シナリオの内容をコマンドライン引数で指定する方針で協議しましたが、追加シナリオ数が不定（optunaと同様）であることと、実施条件が複雑になった場合、条件を config として残しておくという需要があると考えたため、config へ記述する形式でひとまず作成しています。

## 主な変更点
- ### optimizer.py
    config に additional_scenario があった場合は追加のシナリオを実行するように変更