### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include aiaccel/hpo/apps/config/*.yaml


### PR DESCRIPTION
`pip install .` で、`aiacel/hpo/apps/config/*.yaml` がインストール先にコピーされない問題を修正