### PR TITLE
Add MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include aiaccel/torch/apps/config/*.yaml


### PR DESCRIPTION
- 仮想環境にインストールした aiaccel に aiaccel/torch/apps/config/*.yaml が含まれていなかったため、それらをインストールできるように [MANIFEST.in](https://github.com/aistairc/aiaccel/compare/develop/v2...feature/v2-add_MANIFEST_in?expand=1#diff-41d5a52589e0480be9c099d2bba7a8135b8b0d71bcbb8df3582a8df1c2295003) を追加しました。