### PR TITLE
Feature/v2  fix  optimize.py

### DIFF
--- a/aiaccel/hpo/apps/optimize.py
+++ b/aiaccel/hpo/apps/optimize.py
@@ -4,14 +4,12 @@ import argparse
 from collections.abc import Callable
 import importlib.resources
 from pathlib import Path
-import pickle as pkl
 
 from hydra.utils import instantiate
 from omegaconf import OmegaConf as oc  # noqa: N813
 
 from optuna.trial import Trial
 
-from aiaccel.hpo.job_executors import AbciJobExecutor, BaseJobExecutor, LocalJobExecutor
 from aiaccel.hpo.optuna.suggest_wrapper import Const, Suggest, SuggestFloat, T
 from aiaccel.utils import print_config
 
@@ -69,7 +67,6 @@ def main() -> None:
     Command-line arguments:
         - job_filename (Path): The shell script to execute.
         - --config (str, optional): Path to the configuration file.
-        - --executor (str, optional): Type of job executor to use ("local" or "abci").
         - --resume (bool, optional): Flag to resume from the previous study.
 
     The function performs the following steps:
@@ -94,28 +91,31 @@ def main() -> None:
             _target_: optuna.samplers.TPESampler
             seed: 0
 
+        executor:
+            _target_: aiaccel.hpo.job_executors.LocalJobExecutor
+            n_max_jobs: 4
+            loader:
+                _target_: aiaccel.hpo.job_output_loaders.JsonJobOutputLoader
+                filename_template: "{job.cwd}/{job.job_name}_result.json"
+
         params:
-        _convert_: partial
-        _target_: aiaccel.apps.optimize.HparamsManager
-        x1: [0, 1]
-        x2:
-            _target_: aiaccel.apps.optimize.SuggestFloat
-            name: x2
-            low: 0.0
-            high: 1.0
-            log: false
+            _convert_: partial
+            _target_: aiaccel.apps.optimize.HparamsManager
+            x1: [0, 1]
+            x2:
+                _target_: aiaccel.apps.optimize.SuggestFloat
+                name: x2
+                low: 0.0
+                high: 1.0
+                log: false
 
         n_trials: 30
-        n_max_jobs: 4
-
-        group: gaa50000
         ~~~
     """
 
     parser = argparse.ArgumentParser()
     parser.add_argument("job_filename", type=Path, help="The shell script to execute.")
     parser.add_argument("--config", help="Configuration file path")
-    parser.add_argument("--executor", nargs="?", default="local")
     parser.add_argument("--resume", action="store_true", default=False)
     parser.add_argument("--resumable", action="store_true", default=False)
 
@@ -133,22 +133,17 @@ def main() -> None:
 
     print_config(config)
 
-    jobs: BaseJobExecutor
+    config.executor.job_filename = args.job_filename
 
-    if args.executor.lower() == "local":
-        jobs = LocalJobExecutor(args.job_filename, n_max_jobs=config.n_max_jobs)
-    elif args.executor.lower() == "abci":
-        jobs = AbciJobExecutor(args.job_filename, config.group, n_max_jobs=config.n_max_jobs)
-    else:
-        raise ValueError(f"Unknown executor: {args.executor}")
-
+    jobs = instantiate(config.executor)
     study = instantiate(config.study)
     params = instantiate(config.params)
 
-    result_filename_template = "{job.cwd}/{job.job_name}_result.pkl"
+    finished_job_count = 0
 
-    while jobs.finished_job_count < config.n_trials:
-        n_max_jobs = min(jobs.available_slots(), config.n_trials - jobs.submitted_job_count)
+    while finished_job_count < config.n_trials:
+        n_running_jobs = len(jobs.get_running_jobs())
+        n_max_jobs = min(jobs.available_slots(), config.n_trials - finished_job_count - n_running_jobs)
         for _ in range(n_max_jobs):
             trial = study.ask()
 
@@ -157,17 +152,18 @@ def main() -> None:
             jobs.job_name = str(jobs.job_filename) + f"_{trial.number}"
 
             job = jobs.submit(
-                args=[result_filename_template] + sum([[f"--{k}", f"{v:.5f}"] for k, v in hparams.items()], []),
+                args=[jobs.loader.filename_template] + sum([[f"--{k}", f"{v}"] for k, v in hparams.items()], []),
                 tag=trial,
             )
 
         for job in jobs.collect_finished():
             trial = job.tag
 
-            with open(result_filename_template.format(job=job), "rb") as f:
-                y = pkl.load(f)
+            y = job.load()
 
             study.tell(trial, y)
+
+            finished_job_count += 1
 
 
 if __name__ == "__main__":

--- a/aiaccel/hpo/job_executors/abci_job_executor.py
+++ b/aiaccel/hpo/job_executors/abci_job_executor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import time
 
 from aiaccel.hpo.job_executors.base_job_executor import BaseJobExecutor
+from aiaccel.hpo.job_output_loaders.base_loader import BaseJobOutputLoader
 from aiaccel.hpo.jobs.abci_job import AbciJob
 
 
@@ -34,6 +35,7 @@ class AbciJobExecutor(BaseJobExecutor):
         job_name: str | None = None,
         work_dir: Path | str | None = None,
         n_max_jobs: int = 100,
+        loader: BaseJobOutputLoader | None = None,
     ):
         """
         Initialize the AbciJobManager object.
@@ -45,7 +47,7 @@ class AbciJobExecutor(BaseJobExecutor):
             work_dir (Path | str | None, optional): The working directory for the job. Defaults to None.
             n_max_jobs (int, optional): The maximum number of jobs. Defaults to 100.
         """
-        super().__init__(job_filename, job_name, work_dir, n_max_jobs)
+        super().__init__(job_filename, job_name, work_dir, n_max_jobs, loader)
         self.job_group = job_group
         self.job_list: list[AbciJob] = []
 

--- a/aiaccel/hpo/job_executors/base_job_executor.py
+++ b/aiaccel/hpo/job_executors/base_job_executor.py
@@ -3,6 +3,7 @@ from typing import Any
 from abc import ABC, abstractmethod
 from pathlib import Path
 
+from aiaccel.hpo.job_output_loaders.base_loader import BaseJobOutputLoader
 from aiaccel.hpo.jobs.base_job import BaseJob
 from aiaccel.hpo.jobs.job_status import JobStatus
 
@@ -31,14 +32,14 @@ class BaseJobExecutor(ABC):
         job_name: str | None = None,
         work_dir: Path | str | None = None,
         n_max_jobs: int = 100,
+        loader: BaseJobOutputLoader | None = None,
     ):
         self.job_filename = job_filename if isinstance(job_filename, Path) else Path(job_filename)
         self.job_name = job_name
         self.work_dir = Path(work_dir) if work_dir is not None else Path.cwd()
         self.work_dir.mkdir(parents=True, exist_ok=True)
-
         self.n_max_jobs = n_max_jobs
-
+        self.loader = loader
         self.job_list: list[Any] = []
 
         self.submitted_job_count = 0

--- a/aiaccel/hpo/job_executors/local_job_executor.py
+++ b/aiaccel/hpo/job_executors/local_job_executor.py
@@ -9,6 +9,7 @@ import time
 import traceback
 
 from aiaccel.hpo.job_executors.base_job_executor import BaseJobExecutor
+from aiaccel.hpo.job_output_loaders.base_loader import BaseJobOutputLoader
 from aiaccel.hpo.jobs.local_job import LocalJob
 
 
@@ -21,6 +22,7 @@ class LocalJobExecutor(BaseJobExecutor):
         job_name: str | None = None,
         work_dir: Path | str | None = None,
         n_max_jobs: int = 1,
+        loader: BaseJobOutputLoader | None = None,
     ):
         """
         Initialize the AbciJobManager object.
@@ -32,7 +34,7 @@ class LocalJobExecutor(BaseJobExecutor):
             work_dir (Path | str | None, optional): The working directory for the job. Defaults to None.
             n_max_jobs (int, optional): The maximum number of jobs. Defaults to 100.
         """
-        super().__init__(job_filename, job_name, work_dir, n_max_jobs)
+        super().__init__(job_filename, job_name, work_dir, n_max_jobs, loader)
         self.executor = ProcessPoolExecutor(max_workers=n_max_jobs)
 
         self.cwd = Path(work_dir) if work_dir is not None else Path.cwd()
@@ -66,7 +68,12 @@ class LocalJobExecutor(BaseJobExecutor):
 
         future = self.executor.submit(self.run, cmd, self.cwd)
         job_future = LocalJob(
-            future, job_filename=self.job_filename, job_name=self.job_name, cwd=self.work_dir, tag=tag
+            future,
+            job_filename=self.job_filename,
+            job_name=self.job_name,
+            cwd=self.work_dir,
+            tag=tag,
+            loader=self.loader,
         )
 
         self.job_list.append(job_future)

--- a/aiaccel/hpo/job_output_loaders/__init__.py
+++ b/aiaccel/hpo/job_output_loaders/__init__.py
@@ -1,0 +1,6 @@
+from aiaccel.hpo.job_output_loaders.base_loader import BaseJobOutputLoader
+from aiaccel.hpo.job_output_loaders.json_loader import JsonJobOutputLoader
+from aiaccel.hpo.job_output_loaders.pickle_loader import PickleJobOutputLoader
+from aiaccel.hpo.job_output_loaders.stdout_loader import StdoutJobOutputLoader
+
+__all__ = ["BaseJobOutputLoader", "PickleJobOutputLoader", "JsonJobOutputLoader", "StdoutJobOutputLoader"]

--- a/aiaccel/hpo/job_output_loaders/base_loader.py
+++ b/aiaccel/hpo/job_output_loaders/base_loader.py
@@ -1,0 +1,16 @@
+from typing import Protocol
+
+from pathlib import Path
+
+
+class BaseJob(Protocol):
+    job_name: str
+    cwd: Path
+
+
+class BaseJobOutputLoader:
+    def __init__(self, filename_template: str) -> None:
+        self.filename_template = filename_template
+
+    def load(self, job: BaseJob) -> int | float | str:
+        raise NotImplementedError

--- a/aiaccel/hpo/job_output_loaders/json_loader.py
+++ b/aiaccel/hpo/job_output_loaders/json_loader.py
@@ -1,0 +1,36 @@
+import json
+
+from aiaccel.hpo.job_output_loaders.base_loader import BaseJob, BaseJobOutputLoader
+
+
+class JsonJobOutputLoader(BaseJobOutputLoader):
+    """
+    A class to handle loading results from JSON files.
+
+    Attributes:
+        filename_template (str): A template for the filename where results are stored.
+
+    Methods:
+        __init__(filename_template: str) -> None:
+            Initializes the JsonJobOutputLoader with a filename template.
+
+        load(job: BaseJob) -> int | float | str:
+            Loads the result from a JSON file based on the job information.
+    """
+
+    def __init__(self, filename_template: str) -> None:
+        super().__init__(filename_template)
+
+    def load(self, job: BaseJob) -> int | float | str:
+        """
+        Loads the objective value from a JSON file for the given job.
+
+        Args:
+            job (BaseJob): The job instance containing job-specific information.
+
+        Returns:
+            int | float | str: The objective value extracted from the JSON file.
+        """
+        with open(self.filename_template.format(job=job)) as f:
+            y: int | float | str = json.load(f)
+        return y

--- a/aiaccel/hpo/job_output_loaders/pickle_loader.py
+++ b/aiaccel/hpo/job_output_loaders/pickle_loader.py
@@ -1,0 +1,36 @@
+import pickle as pkl
+
+from aiaccel.hpo.job_output_loaders.base_loader import BaseJob, BaseJobOutputLoader
+
+
+class PickleJobOutputLoader(BaseJobOutputLoader):
+    """
+    A class to handle the loading of results from pickle files.
+
+    Attributes:
+        filename_template (str): A template for the filename where results are stored.
+
+    Methods:
+        __init__(filename_template: str) -> None:
+            Initializes the PickleJobOutputLoader with a filename template.
+
+        load(job: BaseJob) -> int | float | str:
+            Loads the result from a pickle file corresponding to the given job.
+    """
+
+    def __init__(self, filename_template: str) -> None:
+        super().__init__(filename_template)
+
+    def load(self, job: BaseJob) -> int | float | str:
+        """
+        Loads the result of a job from a pickle file.
+
+        Args:
+            job (BaseJobExecutor): The job executor instance for which the result is to be loaded.
+
+        Returns:
+            int | float | str: The result of the job, which can be an integer, float, or string.
+        """
+        with open(self.filename_template.format(job=job), "rb") as f:
+            y: int | float | str = pkl.load(f)
+        return y

--- a/aiaccel/hpo/job_output_loaders/stdout_loader.py
+++ b/aiaccel/hpo/job_output_loaders/stdout_loader.py
@@ -1,0 +1,53 @@
+import ast
+
+from aiaccel.hpo.job_output_loaders.base_loader import BaseJob, BaseJobOutputLoader
+
+
+class StdoutJobOutputLoader(BaseJobOutputLoader):
+    """
+    A class to handle the loading of results from a stdout file.
+
+    Args:
+        filename_template (str): A template for the filename where the results are stored.
+
+    Methods:
+        load(job: BaseJob) -> int | float | str:
+            Loads the result from the file corresponding to the given job.
+            The result is expected to be on the last non-empty line of the file.
+            Returns the result as an integer, float, or string, depending on the content.
+            Raises a ValueError if the file is empty or contains no non-empty lines.
+    """
+
+    def __init__(self, filename_template: str) -> None:
+        super().__init__(filename_template)
+
+    def load(self, job: BaseJob) -> int | float | str:
+        """
+        Loads the result from a file associated with the given job.
+
+        This method reads the file specified by `self.filename_template` formatted with the given job.
+        It reads the file line by line in reverse order to find the last non-empty line.
+        The method attempts to convert the last non-empty line to an integer, then to a float,
+        and if both conversions fail, it returns the line as a string.
+
+        Args:
+            job (BaseJobExecutor): The job executor instance containing job-specific information.
+
+        Returns:
+            int | float | str: The value from the last non-empty line of the file, converted to an int,
+                               float, or returned as a string.
+
+        Raises:
+            ValueError: If the file is empty or contains no non-empty lines.
+        """
+        with open(self.filename_template.format(job=job)) as f:
+            text = f.read()
+
+            if text is None:
+                raise ValueError("No non-empty lines found in file")
+
+            try:
+                data: int | float | str = ast.literal_eval(text)
+                return data
+            except (ValueError, SyntaxError):
+                return text

--- a/aiaccel/hpo/jobs/abci_job.py
+++ b/aiaccel/hpo/jobs/abci_job.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from xml.etree import ElementTree
 
-from aiaccel.hpo.jobs.base_job import BaseJob
+from aiaccel.hpo.jobs.base_job import BaseJob, JobOutputLoaderProtocol
 from aiaccel.hpo.jobs.job_status import JobStatus
 
 
@@ -45,6 +45,7 @@ class AbciJob(BaseJob):
         qsub_args: list[str] | None = None,
         args: list[str] | None = None,
         tag: Any = None,
+        loader: JobOutputLoaderProtocol | None = None,
     ):
         """
         Initializes a new instance of the AbciJob class.
@@ -64,7 +65,7 @@ class AbciJob(BaseJob):
             args (list[str] | None, optional): Additional arguments to pass to the job file. Defaults to None.
             tag (Any, optional): A tag associated with the job. Defaults to None.
         """
-        super().__init__(job_filename, job_name, cwd, tag)
+        super().__init__(job_filename, job_name, cwd, tag, loader)
 
         self.job_group = job_group
 

--- a/aiaccel/hpo/jobs/local_job.py
+++ b/aiaccel/hpo/jobs/local_job.py
@@ -5,7 +5,7 @@ from typing import Any
 from concurrent.futures import Future
 from pathlib import Path
 
-from aiaccel.hpo.jobs.base_job import BaseJob
+from aiaccel.hpo.jobs.base_job import BaseJob, JobOutputLoaderProtocol
 from aiaccel.hpo.jobs.job_status import JobStatus
 
 
@@ -17,8 +17,9 @@ class LocalJob(BaseJob):
         job_name: str | None = None,
         cwd: Path | None = None,
         tag: Any = None,
+        loader: JobOutputLoaderProtocol | None = None,
     ):
-        super().__init__(job_filename, job_name, cwd, tag)
+        super().__init__(job_filename, job_name, cwd, tag, loader)
         self.future = future
 
     @classmethod

--- a/aiaccel/torch/apps/config/train_base.yaml
+++ b/aiaccel/torch/apps/config/train_base.yaml
@@ -6,3 +6,4 @@ trainer:
     _target_: lightning.pytorch.loggers.TensorBoardLogger
     save_dir: ${working_directory}
     name: ''
+    version: ''

--- a/aiaccel/torch/apps/config/train_ddp.yaml
+++ b/aiaccel/torch/apps/config/train_ddp.yaml
@@ -1,15 +1,9 @@
+_base_: ${base_config_path}/train_base.yaml
+
 trainer:
-  _target_: lightning.Trainer
-  default_root_dir: ${working_directory}
-  
   sync_batchnorm: true
   
   plugins:
     _target_: aiaccel.torch.lightning.abci_environment.ABCIEnvironment
   devices: ${oc.decode:${oc.env:OMPI_COMM_WORLD_LOCAL_SIZE}}
   num_nodes: ${oc.decode:${oc.env:OMPI_MCA_orte_num_nodes}}
-
-  logger:
-    _target_: lightning.pytorch.loggers.TensorBoardLogger
-    save_dir: ${working_directory}
-    name: ''

--- a/aiaccel/torch/apps/train.py
+++ b/aiaccel/torch/apps/train.py
@@ -1,64 +1,66 @@
 from argparse import ArgumentParser
 import os
 from pathlib import Path
-import pickle as pkl
 
 from hydra.utils import instantiate
 from omegaconf import OmegaConf as oc  # noqa: N813
 
 import lightning as lt
 
-from aiaccel.utils import print_config
+from aiaccel.utils import load_config, pathlib2str_config, print_config
 
 
 def main() -> None:
     """
-    Main function to execute the training process.
-    This function parses command-line arguments to get the configuration file
-    and working directory, loads and merges configuration settings from various
-    sources, prints the configuration if the process is the main one, saves the
-    configuration to a file, and then initiates the training process using the
-    specified trainer, model, and datamodule.
-    Command-line Arguments:
-        config (Path): Path to the configuration file in YAML format.
-        --working_directory (Path): Path to the working directory (default is the current working directory).
-    Raises:
-        FileNotFoundError: If the configuration file does not exist.
-        Exception: If there is an error during the training process.
+    Execute the training process using a configuration file.
 
-    Usage:
-        python -m aiaccel.torch.apps.train train.yaml --working_directory /path/to/working/directory
+    This function:
+    1. Parses command-line arguments to get the configuration file and working directory.
+    2. Loads and merges configurations from the YAML file, command-line arguments, and default settings.
+    3. Prints the final configuration.
+    4. Saves the merged configuration to a file (`${working_directory}/config_merged.yaml`).
+    5. Instantiates and runs the training process using the specified trainer, model, and datamodule.
+
+    Command-line Arguments:
+        config (Path): Path to the YAML configuration file.
+        --working_directory (Path, optional): Path to the working directory (default: current working directory).
+
+    Usage Example:
+        ```bash
+        python -m aiaccel.torch.apps.train config.yaml --working_directory /path/to/working/directory
+        ```
+        You can also update some configurations from CLI as follows:
+        ```bash
+        python -m aiaccel.torch.apps.train config.yaml task.hparam1=1.0 task.hparam2=2.0 ...
+        ```
     """
 
     parser = ArgumentParser()
-    parser.add_argument("config", type=Path, help="Config file in YAML format")
-    parser.add_argument("--working_directory", type=Path, default=Path.cwd(), help="Working directory")
+    parser.add_argument("config", type=str, help="Config file in YAML format")
+    parser.add_argument("--working_directory", type=str, default=str(Path.cwd()), help="Working directory")
     args, unk_args = parser.parse_known_args()
 
     # load config
-    config = oc.merge(
-        {
-            "base_config_path": str(Path(__file__).parent / "config"),
-            "base_config": "${base_config_path}/train_base.yaml",
-        },
-        vars(args),
-        oc.load(args.config),
-        oc.from_cli(unk_args),
-    )
+    config = load_config(args.config, {"base_config_path": str(Path(__file__).parent / "config")} | vars(args))
+    config = oc.merge(config, oc.from_cli(unk_args))
 
-    config = oc.merge(
-        oc.load(config.base_config),
-        config,
-    )
-
-    if "OMPI_COMM_WORLD_RANK" not in os.environ or int(os.environ["OMPI_COMM_WORLD_RANK"]) == 0:
+    if int(os.environ.get("OMPI_COMM_WORLD_RANK", 0)) == 0 and int(os.environ.get("RANK", 0)) == 0:
         print_config(config)
 
-        with open(config.working_directory / "config.pkl", "wb") as f:
-            pkl.dump(config, f)
-
-    # train
+    # build trainer
     trainer: lt.Trainer = instantiate(config.trainer)
+
+    # save config
+    if trainer.is_global_zero:
+        if "merged_config_path" in config:
+            merged_config_path = config.merged_config_path
+        else:
+            merged_config_path = Path(config.working_directory) / "config_merged.yaml"
+
+        with open(merged_config_path, "w") as f:
+            oc.save(pathlib2str_config(config), f)
+
+    # start training
     trainer.fit(
         model=instantiate(config.task),
         datamodule=instantiate(config.datamodule),

--- a/aiaccel/utils/__init__.py
+++ b/aiaccel/utils/__init__.py
@@ -1,3 +1,3 @@
-from aiaccel.utils.config import pathlib2str_config, print_config
+from aiaccel.utils.config import load_config, pathlib2str_config, print_config
 
-__all__ = ["print_config", "pathlib2str_config"]
+__all__ = ["load_config", "print_config", "pathlib2str_config"]

--- a/aiaccel/utils/config.py
+++ b/aiaccel/utils/config.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Any
 
 from copy import deepcopy
 from pathlib import Path
@@ -9,7 +9,62 @@ from omegaconf import DictConfig, ListConfig
 from omegaconf import OmegaConf as oc  # noqa:N813
 
 
+def load_config(
+    config_filename: str | Path,
+    parent_config: dict[str, Any] | DictConfig | ListConfig | None = None,
+) -> DictConfig | ListConfig:
+    """Load YAML configuration
+
+    When the user specifies ``_base_``, the specified YAML file is loaded as the base,
+    and the original configuration is merged with the base config.
+    If the configuration specified in ``_base_`` also contains ``_base_``, the process is handled recursively.
+
+    Additionally, if `bootstrap_config` is provided, it is merged with the final
+    configuration to ensure any default values or overrides are applied.
+
+    Args:
+        config (Path): Path to the configuration
+        parent_config (dict[str, Any] | DictConfig | ListConfig | None):
+            A configuration that is merged to the loaded configuration.
+            This is intended to define default config paths (e.g., working_directory) dynamically.
+
+    Returns:
+        merge_user_config (DictConfig): The merged configuration of the base config and the original config
+        user_config(DictConfig | ListConfig) : The configuration without ``_base_``
+
+    """
+
+    if parent_config is None:
+        parent_config = {}
+
+    config = oc.merge(oc.load(config_filename), parent_config)
+
+    if isinstance(config, DictConfig) and "_base_" in config:
+        base_paths = config["_base_"]
+        if not isinstance(base_paths, ListConfig):
+            base_paths = [base_paths]
+
+        config.pop("_base_")
+        for base_path in base_paths:
+            config = load_config(base_path, config)
+
+    return config
+
+
 def print_config(config: ListConfig | DictConfig, line_length: int = 80) -> None:
+    """
+    Print the given configuration with syntax highlighting.
+
+    This function converts `pathlib.Path` objects to strings before printing,
+    ensuring that the output YAML format remains valid. It also highlights
+    configuration keys in yellow for better readability.
+
+    Args:
+        config (ListConfig | DictConfig): The configuration to print.
+        line_length (int, optional): The width of the separator line (default: 80).
+
+    """
+
     config = pathlib2str_config(config)  # https://github.com/omry/omegaconf/issues/82
 
     print("=" * line_length)
@@ -19,6 +74,21 @@ def print_config(config: ListConfig | DictConfig, line_length: int = 80) -> None
 
 
 def pathlib2str_config(config: ListConfig | DictConfig) -> ListConfig | DictConfig:
+    """
+    Convert `pathlib.Path` objects in the configuration to strings.
+
+    This function recursively traverses the configuration and replaces all `pathlib.Path`
+    objects with their string representations. This is useful for saving the configuration
+    in a YAML file, as YAML does not support `Path` objects.
+
+    Args:
+        config (ListConfig | DictConfig): The configuration to convert.
+
+    Returns:
+        ListConfig | DictConfig: The modified configuration with `Path` objects replaced by strings.
+
+    """
+
     def _inner_fn(config: ListConfig | DictConfig) -> ListConfig | DictConfig:
         if isinstance(config, ListConfig):
             for ii in range(len(config)):

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -9,5 +9,6 @@ Config Utilities
 .. autosummary::
     :toctree: generated/
 
+    load_config
     print_config
     pathlib2str_config

--- a/docs/source/user_guide/hpo.rst
+++ b/docs/source/user_guide/hpo.rst
@@ -72,10 +72,9 @@ Basic configuration example:
     executor:
       _target_: aiaccel.hpo.job_executors.LocalJobExecutor
       n_max_jobs: 4
-
-    result:
-      _target_: aiaccel.results.JsonResult
-      filename_template: "{job.cwd}/{job.job_name}_result.json"
+      loader:
+        _target_: aiaccel.hpo.job_output_loaders.JsonResult
+        filename_template: "{job.cwd}/{job.job_name}_result.json"
 
     params:
       x1: [0, 1]
@@ -124,9 +123,11 @@ JSON Format (Default):
 
 .. code-block:: yaml
 
-    result:
-      _target_: aiaccel.results.JsonResult
-      filename_template: "{job.cwd}/{job.job_name}_result.json"
+    executor:
+      ...
+      loader:
+        _target_: aiaccel.hpo.job_output_loaders.JsonResult
+        filename_template: "{job.cwd}/{job.job_name}_result.json"
 
 Example objective function for JSON:
 
@@ -147,9 +148,11 @@ Pickle Format:
 
 .. code-block:: yaml
 
-    result:
-      _target_: aiaccel.results.PickleResult
-      filename_template: "{job.cwd}/{job.job_name}_result.pkl"
+    executor:
+      ...
+      loader:
+        _target_: aiaccel.hpo.job_output_loaders.PickleResult
+        filename_template: "{job.cwd}/{job.job_name}_result.pkl"
 
 Example objective function for Pickle:
 
@@ -170,9 +173,11 @@ Stdout Format:
 
 .. code-block:: yaml
 
-    result:
-      _target_: aiaccel.results.StdoutResult
-      filename_template: "{job.cwd}/{job.job_name}_result.txt"
+    executor:
+      ...
+      loader:
+        _target_: aiaccel.hpo.job_output_loaders.StdoutResult
+        filename_template: "{job.cwd}/{job.job_name}_result.txt"
 
 Example objective function for Stdout:
 

--- a/extensions.txt
+++ b/extensions.txt
@@ -1,1 +1,0 @@
-sphinx_fontawesome==0.0.6

--- a/tests/hpo/apps/main/config.yaml
+++ b/tests/hpo/apps/main/config.yaml
@@ -15,6 +15,13 @@ study:
     _target_: optuna.samplers.TPESampler
     seed: 0
 
+executor:
+  _target_: aiaccel.hpo.job_executors.LocalJobExecutor
+  n_max_jobs: 1
+  loader:
+    _target_: aiaccel.hpo.job_output_loaders.PickleJobOutputLoader
+    filename_template: "{job.cwd}/{job.job_name}_result.pkl"
+
 params:
   _convert_: partial
   _target_: aiaccel.hpo.apps.optimize.HparamsManager
@@ -27,6 +34,3 @@ params:
     log: false
 
 n_trials: 30
-n_max_jobs: 1
-
-group: gaa50000

--- a/tests/hpo/apps/main/in_memory.yaml
+++ b/tests/hpo/apps/main/in_memory.yaml
@@ -7,6 +7,13 @@ study:
     _target_: optuna.samplers.TPESampler
     seed: 0
 
+executor:
+  _target_: aiaccel.hpo.job_executors.LocalJobExecutor
+  n_max_jobs: 1
+  loader:
+    _target_: aiaccel.hpo.job_output_loaders.PickleJobOutputLoader
+    filename_template: "{job.cwd}/{job.job_name}_result.pkl"
+
 params:
   _convert_: partial
   _target_: aiaccel.hpo.apps.optimize.HparamsManager
@@ -19,6 +26,3 @@ params:
     log: false
 
 n_trials: 30
-n_max_jobs: 1
-
-group: gaa50000

--- a/tests/hpo/job_output_loaders/config_base.yaml
+++ b/tests/hpo/job_output_loaders/config_base.yaml
@@ -1,14 +1,13 @@
 study:
   _target_: optuna.create_study
   direction: minimize
-  storage:
-    _target_: optuna.storages.InMemoryStorage
-  study_name: aiaccel_study
+  study_name: my_study
   load_if_exists: false
+  sampler:
+    _target_: optuna.samplers.TPESampler
+    seed: 0
 
 executor:
-  _target_: aiaccel.hpo.job_executors.LocalJobExecutor
-  n_max_jobs: 1
   loader:
     _target_: aiaccel.hpo.job_output_loaders.JsonJobOutputLoader
     filename_template: "{job.cwd}/{job.job_name}_result.json"
@@ -16,3 +15,12 @@ executor:
 params:
   _convert_: partial
   _target_: aiaccel.hpo.apps.optimize.HparamsManager
+  x1: [0, 1]
+  x2:
+    _target_: aiaccel.hpo.optuna.suggest_wrapper.SuggestFloat
+    name: x2
+    low: 0.0
+    high: 1.0
+    log: false
+
+n_trials: 30

--- a/tests/hpo/job_output_loaders/objective_for_output_loaders.py
+++ b/tests/hpo/job_output_loaders/objective_for_output_loaders.py
@@ -1,0 +1,32 @@
+from argparse import ArgumentParser
+import json
+from pathlib import Path
+import pickle as pkl
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("dst_filename", type=Path)
+    parser.add_argument("--x1", type=float)
+    parser.add_argument("--x2", type=float)
+    parser.add_argument("--output_type", type=str)  # for test only
+    args = parser.parse_args()
+
+    x1, x2 = args.x1, args.x2
+
+    y = (x1**2) - (4.0 * x1) + (x2**2) - x2 - (x1 * x2)
+
+    if args.output_type == "json":
+        with open(args.dst_filename, "w") as f:
+            json.dump(y, f)
+    elif args.output_type == "pkl":
+        with open(args.dst_filename, "wb") as f:
+            pkl.dump(y, f)
+    elif args.output_type == "stdout":
+        print(y)
+    else:
+        raise AssertionError(f"Invalid output type: {args.output_type}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hpo/job_output_loaders/test_json_output_loadert.py
+++ b/tests/hpo/job_output_loaders/test_json_output_loadert.py
@@ -1,0 +1,100 @@
+from collections.abc import Generator
+import json
+import os
+from pathlib import Path
+import shutil
+import tempfile
+from unittest.mock import patch
+
+from omegaconf import OmegaConf as oc  # noqa: N813
+
+import pytest
+
+from aiaccel.hpo.job_executors import LocalJobExecutor
+from aiaccel.hpo.job_output_loaders.json_loader import JsonJobOutputLoader
+
+
+@pytest.fixture
+def temp_dir() -> Generator[Path]:
+    """Create a temporary directory with test files and clean up afterwards"""
+
+    # create a config file
+    config_path = os.path.join(os.path.dirname(__file__), "config_base.yaml")
+    base = oc.load(config_path)
+    output_loadeer = {
+        "result": {
+            "_target_": "aiaccel.hpo.job_output_loaders.JsonJobOutputLoader",
+            "filename_template": "{job.cwd}/{job.job_name}_result.json",
+        }
+    }
+    config = oc.merge(base, output_loadeer)
+
+    # create objective script
+    src = """
+#!/bin/bash
+python objective_for_output_loaders.py $@ "--output_type" "json"
+"""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        temp_path = Path(tmp_dir)
+        original_dir = os.getcwd()
+        os.chdir(tmp_dir)
+        source_dir = Path(__file__).parent
+
+        source_file = source_dir / "objective_for_output_loaders.py"
+        target_file = temp_path / "objective_for_output_loaders.py"
+        shutil.copy2(source_file, target_file)
+        os.chmod(target_file, 0o755)
+
+        # generate config file
+        oc.save(config, temp_path / "config_for_json_test.yaml")
+
+        # generate objective script
+        with open(temp_path / "objective_for_json_test.sh", "w") as f:
+            f.write(src)
+
+        yield temp_path
+        os.chdir(original_dir)
+
+
+def test_load_int(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.json"
+    with open(dst_filename, "w") as f:
+        f.write(json.dumps(42))
+    loader = JsonJobOutputLoader("{job.cwd}/result.json")
+    job_executor = LocalJobExecutor(Path(""), loader=loader, work_dir=temp_dir)
+    job = job_executor.submit([])
+    json_result = JsonJobOutputLoader("{job.cwd}/result.json")
+    assert json_result.load(job) == 42
+
+
+def test_load_float(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.json"
+    with open(dst_filename, "w") as f:
+        f.write(json.dumps(3.14))
+
+    laoder = JsonJobOutputLoader("{job.cwd}/result.json")
+    job_executor = LocalJobExecutor(Path(""), loader=laoder, work_dir=temp_dir)
+    job = job_executor.submit([])
+    json_result = JsonJobOutputLoader("{job.cwd}/result.json")
+    assert json_result.load(job) == 3.14
+
+
+def test_load_str(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.json"
+    with open(dst_filename, "w") as f:
+        f.write(json.dumps("result"))
+    loader = JsonJobOutputLoader("{job.cwd}/result.json")
+    executor = LocalJobExecutor(Path(""), loader=loader, work_dir=temp_dir)
+    job = executor.submit([])
+    json_result = JsonJobOutputLoader("{job.cwd}/result.json")
+    assert json_result.load(job) == "result"
+
+
+def test_result(temp_dir: Path) -> None:
+    with patch("sys.argv", ["optimize.py", "objective_for_json_test.sh", "--config", "config_for_json_test.yaml"]):
+        from aiaccel.hpo.apps.optimize import main
+
+        main()
+        assert (temp_dir / "objective_for_json_test.sh_29_result.json").exists()
+        assert (temp_dir / "objective_for_json_test.sh_30_result.json").exists() is False

--- a/tests/hpo/job_output_loaders/test_pickle_output_loader.py
+++ b/tests/hpo/job_output_loaders/test_pickle_output_loader.py
@@ -1,0 +1,104 @@
+from collections.abc import Generator
+import os
+from pathlib import Path
+import pickle as pkl
+import shutil
+import tempfile
+from unittest.mock import patch
+
+from omegaconf import OmegaConf as oc  # noqa: N813
+
+import pytest
+
+from aiaccel.hpo.job_executors import LocalJobExecutor
+from aiaccel.hpo.job_output_loaders.pickle_loader import PickleJobOutputLoader
+
+
+@pytest.fixture
+def temp_dir() -> Generator[Path]:
+    """Create a temporary directory with test files and clean up afterwards"""
+
+    # create a config file
+    config_path = os.path.join(os.path.dirname(__file__), "config_base.yaml")
+    base = oc.load(config_path)
+    output_loadeer = {
+        "executor": {
+            "loader": {
+                "_target_": "aiaccel.hpo.job_output_loaders.PickleJobOutputLoader",
+                "filename_template": "{job.cwd}/{job.job_name}_result.pkl",
+            }
+        }
+    }
+    config = oc.merge(base, output_loadeer)
+
+    # create objective script
+    src = """
+#!/bin/bash
+python objective_for_output_loaders.py $@ "--output_type" "pkl"
+"""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        temp_path = Path(tmp_dir)
+        original_dir = os.getcwd()
+        os.chdir(tmp_dir)
+        source_dir = Path(__file__).parent
+
+        source_file = source_dir / "objective_for_output_loaders.py"
+        target_file = temp_path / "objective_for_output_loaders.py"
+        shutil.copy2(source_file, target_file)
+        os.chmod(target_file, 0o755)
+
+        # generate config file
+        oc.save(config, temp_path / "config_for_pkl_test.yaml")
+
+        # generate objective script
+        with open(temp_path / "objective_for_pkl_test.sh", "w") as f:
+            f.write(src)
+
+        yield temp_path
+        os.chdir(original_dir)
+
+
+def test_load_int(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.pkl"
+    with open(dst_filename, "wb") as f:
+        pkl.dump(42, f)
+
+    loader = PickleJobOutputLoader("{job.cwd}/result.pkl")
+    job_executor = LocalJobExecutor(Path(""), loader=loader, work_dir=temp_dir)
+    job = job_executor.submit(args=[])
+    pkl_result = PickleJobOutputLoader("{job.cwd}/result.pkl")
+    assert pkl_result.load(job) == 42
+
+
+def test_load_float(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.pkl"
+    with open(dst_filename, "wb") as f:
+        pkl.dump(3.14, f)
+
+    laoder = PickleJobOutputLoader("{job.cwd}/result.pkl")
+    job_executor = LocalJobExecutor(Path(""), loader=laoder, work_dir=temp_dir)
+    job = job_executor.submit(args=[])
+    pkl_result = PickleJobOutputLoader("{job.cwd}/result.pkl")
+    assert pkl_result.load(job) == 3.14
+
+
+def test_load_str(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.pkl"
+    with open(dst_filename, "wb") as f:
+        pkl.dump("result", f)
+
+    loader = PickleJobOutputLoader("{job.cwd}/result.pkl")
+    job_executor = LocalJobExecutor(Path(""), loader=loader, work_dir=temp_dir)
+    job = job_executor.submit(args=[])
+    pkl_result = PickleJobOutputLoader("{job.cwd}/result.pkl")
+    assert pkl_result.load(job) == "result"
+
+
+def test_result(temp_dir: Path) -> None:
+    with patch("sys.argv", ["optimize.py", "objective_for_pkl_test.sh", "--config", "config_for_pkl_test.yaml"]):
+        from aiaccel.hpo.apps.optimize import main
+
+        main()
+        assert (temp_dir / "objective_for_pkl_test.sh_29_result.pkl").exists()
+        assert (temp_dir / "objective_for_pkl_test.sh_30_result.pkl").exists() is False

--- a/tests/hpo/job_output_loaders/test_stdout_output_loader.py
+++ b/tests/hpo/job_output_loaders/test_stdout_output_loader.py
@@ -1,0 +1,100 @@
+from collections.abc import Generator
+import os
+from pathlib import Path
+import shutil
+import tempfile
+from unittest.mock import patch
+
+from omegaconf import OmegaConf as oc  # noqa: N813
+
+import pytest
+
+from aiaccel.hpo.job_executors import LocalJobExecutor
+from aiaccel.hpo.job_output_loaders.stdout_loader import StdoutJobOutputLoader
+
+
+@pytest.fixture
+def temp_dir() -> Generator[Path]:
+    """Create a temporary directory with test files and clean up afterwards"""
+
+    # create a config file
+    config_path = os.path.join(os.path.dirname(__file__), "config_base.yaml")
+    base = oc.load(config_path)
+    output_loadeer = {
+        "executor": {
+            "loader": {
+                "_target_": "aiaccel.hpo.job_output_loaders.StdoutJobOutputLoader",
+                "filename_template": "{job.cwd}/{job.job_name}_result.txt",
+            }
+        }
+    }
+    config = oc.merge(base, output_loadeer)
+
+    # create objective script
+    src = """
+#!/bin/bash
+python objective_for_output_loaders.py "${@:2}" "--output_type" "stdout" > "$1"
+"""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        temp_path = Path(tmp_dir)
+        original_dir = os.getcwd()
+        os.chdir(tmp_dir)
+        source_dir = Path(__file__).parent
+
+        source_file = source_dir / "objective_for_output_loaders.py"
+        target_file = temp_path / "objective_for_output_loaders.py"
+        shutil.copy2(source_file, target_file)
+        os.chmod(target_file, 0o755)
+
+        # generate config file
+        oc.save(config, temp_path / "config_for_stdo_test.yaml")
+
+        # generate objective script
+        with open(temp_path / "objective_for_stdo_test.sh", "w") as f:
+            f.write(src)
+
+        yield temp_path
+        os.chdir(original_dir)
+
+
+def test_load_int(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.txt"
+    with open(dst_filename, "w") as f:
+        f.write("42")
+    loader = StdoutJobOutputLoader("{job.cwd}/result.txt")
+    job_executor = LocalJobExecutor(Path(""), loader=loader, work_dir=temp_dir)
+    job = job_executor.submit(args=[])
+    stdout_result = StdoutJobOutputLoader("{job.cwd}/result.txt")
+    assert stdout_result.load(job) == 42
+
+
+def test_load_float(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.txt"
+    with open(dst_filename, "w") as f:
+        f.write("3.14")
+    loader = StdoutJobOutputLoader("{job.cwd}/result.txt")
+    job_executor = LocalJobExecutor(Path(""), loader=loader, work_dir=temp_dir)
+    job = job_executor.submit(args=[])
+    stdout_result = StdoutJobOutputLoader("{job.cwd}/result.txt")
+    assert stdout_result.load(job) == 3.14
+
+
+def test_load_str(temp_dir: Path) -> None:
+    dst_filename = temp_dir / "result.txt"
+    with open(dst_filename, "w") as f:
+        f.write("result")
+    loader = StdoutJobOutputLoader("{job.cwd}/result.txt")
+    job_executor = LocalJobExecutor(Path(""), loader=loader, work_dir=temp_dir)
+    job = job_executor.submit(args=[])
+    stdout_result = StdoutJobOutputLoader("{job.cwd}/result.txt")
+    assert stdout_result.load(job) == "result"
+
+
+def test_result(temp_dir: Path) -> None:
+    with patch("sys.argv", ["optimize.py", "objective_for_stdo_test.sh", "--config", "config_for_stdo_test.yaml"]):
+        from aiaccel.hpo.apps.optimize import main
+
+        main()
+        assert (temp_dir / "objective_for_stdo_test.sh_29_result.txt").exists()
+        assert (temp_dir / "objective_for_stdo_test.sh_30_result.txt").exists() is False


### PR DESCRIPTION
### executr の指定を config から指定するように変更 (以前はコマンドライン引数で指定)

config でexecutorの指定がない場合はデフォルトの local をセットする 

- local
``` yaml
executor:
  _target_: aiaccel.hpo.job_executors.LocalJobExecutor
  n_max_jobs: 4
```

- abci
``` yaml
executor:
  _target_: aiaccel.hpo.job_executors.AbciobExecutor
  n_max_jobs: 4
  group: gaa50000
```

### 出力フォーマットのの設定を config から指定するように変更 

config で result の指定がない場合はデフォルトの json をセットする 

- json
``` yaml
result:
  _target_: aiaccel.hpo.results.JsonResult
  filename_template: "{job.cwd}/{job.job_name}_result.json" 
```

- pickle
``` yaml
result:
  _target_: aiaccel.hpo.results.PickleResult
  filename_template: "{job.cwd}/{job.job_name}_result.pkl"
```

- stdout
``` yaml
result:
  _target_: aiaccel.hpo.results.StdoutResult
  filename_template: "{job.cwd}/{job.job_name}_result.txt"
```
