### PR TITLE
Fix for docstrfmt.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,10 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-  # - repo: https://github.com/LilSpazJoekp/docstrfmt
-  #   rev: v1.10.0
-  #   hooks:
-  #     - id: docstrfmt
-  #       args: [docs/source/]
-  #       exclude: docs/source/api_reference/generated
+  - repo: https://github.com/LilSpazJoekp/docstrfmt
+    rev: v1.10.0
+    hooks:
+      - id: docstrfmt
+        args: [--check, docs/source/]
+        types_or: [rst]
+        exclude: docs/source/api_reference/generated


### PR DESCRIPTION
aiaccel 以下のソースコードの docstring を変更した際に、pre-commit で docstrfmt がそれらに対して動作してしまう現象を修正しました

- オプション等で docstring に対する docstrfmt の挙動を変更する方法は見つかりませんでした。
- なので、docstrfmt が rst ファイルにのみ動作するように修正しました
  - types_or の項目を追加し、そこで rst のみを指定することで、rst にのみ docstrfmt が動作するようにしました