### PR TITLE
Add copy button in document.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "pydata_sphinx_theme",
     "sphinx.ext.doctest",
     "sphinx_design",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "lightning>=2.2.1",
     "torch>=2.2.0",
     "h5py",
-    "dask-jobqueue"
+    "dask-jobqueue",
+    "rich"
 ]
 
 [project.urls]
@@ -47,6 +48,7 @@ dev = [
     "sphinx-intl",
     "sphinx-fontawesome",
     "sphinx-rtd-theme",
+    "sphinx-copybutton",
     "pydata-sphinx-theme",
     "sphinx_design",
     "types-colorama",


### PR DESCRIPTION
ドキュメントにコピーボタンを生成する拡張機能を追加しました

![Screenshot from 2025-04-25 11-29-44](https://github.com/user-attachments/assets/4998ad8d-7159-4047-91ac-e8673be0e251)

- ドキュメント生成時に aiaccel.torch.h5py.hdf5_writer の rich がインストールされていない旨のエラーが出たため、そちらのインストールも pyproject.toml に追加しました。