### PR TITLE
Fix ruff version in pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.12.2
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
pre-commit と git の CI 上との ruff のバージョン差分の影響で、pre-commit は pass する一方、 git の CI は failed になる現象が発生したので、pre-commit 側の ruff バージョンを修正しました