### PR TITLE
Update pypi-publish.yaml

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -81,8 +81,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
* バージョン名を%mから%-mに変更．PEP 440 に合わせる．https://peps.python.org/pep-0440/#final-releases
  旧 2025.07 -> 新 2025.7

* 日付を前倒し (元に戻し) で25->20日へ．