### PR TITLE
Fix aiaccel/launcher for distributed processing with PyTorch Lightning

### DIFF
--- a/aiaccel/launcher.py
+++ b/aiaccel/launcher.py
@@ -20,7 +20,7 @@ def main() -> None:
     parser.add_argument("command", choices=modules, help="The command to run.")
     args, unk_args = parser.parse_known_args()
 
-    sys.argv = [f"{sys.argv[0]} {args.command}"] + unk_args
+    sys.argv = [f"{sys.argv[0]}"] + [f"{args.command}"] + unk_args
     importlib.import_module(f"aiaccel.{target_module}.apps.{args.command}").main()
 
 

--- a/aiaccel/launcher.py
+++ b/aiaccel/launcher.py
@@ -20,8 +20,9 @@ def main() -> None:
     parser.add_argument("command", choices=modules, help="The command to run.")
     args, unk_args = parser.parse_known_args()
 
-    sys.argv = [f"{sys.argv[0]}"] + [f"{args.command}"] + unk_args
-    importlib.import_module(f"aiaccel.{target_module}.apps.{args.command}").main()
+    module = importlib.import_module(f"aiaccel.{target_module}.apps.{args.command}")
+    sys.argv = [str(module.__file__)] + unk_args
+    module.main()
 
 
 if __name__ == "__main__":

--- a/aiaccel/torch/apps/train.py
+++ b/aiaccel/torch/apps/train.py
@@ -24,7 +24,7 @@ def main() -> None:
     overwrite_omegaconf_dumper()
 
     parser = ArgumentParser()
-    parser.add_argument("--config", type=str, help="Config file in YAML format")
+    parser.add_argument("config", type=str, help="Config file in YAML format")
     args, unk_args = parser.parse_known_args()
 
     # load config

--- a/aiaccel/torch/apps/train.py
+++ b/aiaccel/torch/apps/train.py
@@ -24,7 +24,7 @@ def main() -> None:
     overwrite_omegaconf_dumper()
 
     parser = ArgumentParser()
-    parser.add_argument("config", type=str, help="Config file in YAML format")
+    parser.add_argument("--config", type=str, help="Config file in YAML format")
     args, unk_args = parser.parse_known_args()
 
     # load config


### PR DESCRIPTION
ABCI上での aiaccel-torch 実行時、分散処理関係で aiaccel-torch の参照に失敗していた現象を改修しました

- 従来の launcher では、aiaccel-torch 実行時に `sys.args = ["aiaccel-torch train"] + unk_args` となっていました
  - 分散処理先で sys.args を参照した際に、 "aiaccel-torch train" を1つのコマンドとして認識し、`[Errno 2] No such file or directory` と表示されていたと推測されます
  - python -m aiaccel.torch.apps.train を実行した際の sys.args に合わせて、`sys.argv = [str(module.__file__)] + unk_args` に変更することで、ABCI上 で aiaccel-torch を実行できることを確認し、改修しました
  - この方法であれば、jobs, optimize に影響は出ないと思われます