### PR TITLE
Add get_value in config.apps

### DIFF
--- a/aiaccel/config/apps/get_value.py
+++ b/aiaccel/config/apps/get_value.py
@@ -1,6 +1,6 @@
 import argparse
 
-from omegaconf import OmegaConf as oc
+from omegaconf import OmegaConf as oc  # noqa: N813
 
 from aiaccel.config.config import load_config, overwrite_omegaconf_dumper, resolve_inherit
 
@@ -16,7 +16,7 @@ def main() -> None:
     config = load_config(args.config)
     config = resolve_inherit(config)
 
-    print(oc.select(config, key))
+    print(oc.select(config, args.key))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
config/apps にconfig と key を与えて、value を表示するアプリ get_value を追加しました

```
$ aiaccel-config get_value aiaccel/torch/apps/config/train_base.yaml --key trainer logger
{'_target_': 'lightning.pytorch.loggers.TensorBoardLogger', 'save_dir': '${working_directory}', 'name': '', 'version': ''}
$ aiaccel-config get_value aiaccel/torch/apps/config/train_base.yaml --key trainer hoge
None
```
