### PR TITLE
Bugfix on `aiaccel-job local`

### DIFF
--- a/aiaccel/job/apps/config/local.yaml
+++ b/aiaccel/job/apps/config/local.yaml
@@ -9,7 +9,7 @@ cpu:
     job: "{command}"
 
 cpu-array:
-    n_tasks_per_proc: 128
+    n_tasks_per_proc: null
     n_procs: 24
     job: "{command}"
 
@@ -17,7 +17,7 @@ gpu:
     job: "{command}"
 
 gpu-array:
-    n_tasks_per_proc: 128
+    n_tasks_per_proc: null
     n_procs: 8
     job: "CUDA_VISIBLE_DEVICES=$(( LOCAL_PROC_INDEX % {args.n_procs} )) {command}"
 


### PR DESCRIPTION
This pull request updates the local job execution logic for array jobs in the `aiaccel` project, improving how tasks are distributed among processes and updating the related configuration. The main changes include dynamically calculating the number of tasks per process and generating a shell script to manage parallel execution and logging for each process.

**Improvements to job execution logic:**

* The `cpu-array` and `gpu-array` sections in `local.yaml` now set `n_tasks_per_proc` to `null`, allowing the value to be determined dynamically at runtime rather than being hardcoded.
* In `local.py`, the main function now calculates `n_tasks_per_proc` using `ceil(args.n_tasks / args.n_procs)`, ensuring an even distribution of tasks across processes. It generates a shell script that launches each process with the appropriate environment variables and handles per-process logging.

**Code maintenance and compatibility:**

* Added import of `ceil` from the `math` module in `local.py` to support the new calculation for tasks per process.
* The script now warns if the `n_tasks_per_procs` argument (note the plural) is provided, clarifying that it is ignored for compatibility.