### PR TITLE
Add no_buffer_weight_averaging.py

### DIFF
--- a/aiaccel/torch/lightning/callbacks/__init__.py
+++ b/aiaccel/torch/lightning/callbacks/__init__.py
@@ -2,7 +2,17 @@
 # SPDX-License-Identifier: MIT
 
 from aiaccel.torch.lightning.callbacks.load_pretrained import LoadPretrainedCallback
+from aiaccel.torch.lightning.callbacks.no_buffer_weight_averaging import (
+    NoBufferEMAWeightAveraging,
+    NoBufferWeightAveraging,
+)
 from aiaccel.torch.lightning.callbacks.print_unused_param import PrintUnusedParam
 from aiaccel.torch.lightning.callbacks.save_metric import SaveMetricCallback
 
-__all__ = ["SaveMetricCallback", "LoadPretrainedCallback", "PrintUnusedParam"]
+__all__ = [
+    "SaveMetricCallback",
+    "LoadPretrainedCallback",
+    "PrintUnusedParam",
+    "NoBufferWeightAveraging",
+    "NoBufferEMAWeightAveraging",
+]

--- a/aiaccel/torch/lightning/callbacks/no_buffer_weight_averaging.py
+++ b/aiaccel/torch/lightning/callbacks/no_buffer_weight_averaging.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2025 National Institute of Advanced Industrial Science and Technology (AIST)
+# SPDX-License-Identifier: MIT
+
+from typing import Any
+
+import torch
+from torch.optim.swa_utils import get_ema_avg_fn
+
+from lightning.pytorch import LightningModule
+from lightning.pytorch.callbacks import WeightAveraging
+
+
+class NoBufferWeightAveraging(WeightAveraging):
+    """Weight averaging callback that ignores buffers during averaging and swapping.
+
+    Checkpoints still store the current model buffers together with the averaged
+    parameters so loading preserves non-averaged buffer state.
+
+    Example:
+        >>> from lightning.pytorch import Trainer
+        >>> from torch.optim.swa_utils import get_ema_avg_fn
+        >>> ema = NoBufferWeightAveraging(avg_fn=get_ema_avg_fn(0.999))
+        >>> trainer = Trainer(callbacks=[ema])
+    """
+
+    def __init__(
+        self,
+        device: torch.device | str | int | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize the callback.
+
+        Args:
+            device: Device that stores the averaged model. If ``None``, the
+                current model device is used.
+            **kwargs: Additional arguments forwarded to
+                ``lightning.pytorch.callbacks.WeightAveraging``. ``use_buffers``
+                is always fixed to ``False`` in this subclass.
+        """
+        super().__init__(device, use_buffers=False, **kwargs)
+
+    def _swap_models(self, pl_module: LightningModule) -> None:
+        assert self._average_model is not None
+
+        for average_param, current_param in zip(
+            self._average_model.module.parameters(),
+            pl_module.parameters(),
+            strict=True,
+        ):
+            tmp = average_param.data.clone()
+            average_param.data.copy_(current_param.data)
+            current_param.data.copy_(tmp)
+
+    def _copy_average_to_current(self, pl_module: LightningModule) -> None:
+        assert self._average_model is not None
+
+        for average_param, current_param in zip(
+            self._average_model.module.parameters(),
+            pl_module.parameters(),
+            strict=True,
+        ):
+            current_param.data.copy_(average_param.data)
+
+    def on_save_checkpoint(
+        self,
+        trainer: Any,
+        pl_module: LightningModule,
+        checkpoint: dict[str, Any],
+    ) -> None:
+        super().on_save_checkpoint(trainer, pl_module, checkpoint)
+
+        if self._average_model is None:
+            return
+
+        current_model_state: dict[str, torch.Tensor] | None = checkpoint.get("current_model_state")
+        average_model_state: dict[str, torch.Tensor] | None = checkpoint.get("state_dict")
+        if current_model_state is None or average_model_state is None:
+            return
+
+        # Save averaged parameters together with the current model buffers.
+        buffer_names = {name for name, _ in pl_module.named_buffers()}
+        for buffer_name in buffer_names:
+            if buffer_name in current_model_state:
+                average_model_state[buffer_name] = current_model_state[buffer_name].clone()
+
+
+class NoBufferEMAWeightAveraging(NoBufferWeightAveraging):
+    """Exponential moving average (EMA) version of ``NoBufferWeightAveraging``."""
+
+    def __init__(
+        self,
+        device: torch.device | str | int | None = None,
+        decay: float = 0.999,
+        **kwargs: Any,
+    ):
+        """Initialize the callback.
+
+        Args:
+                take two models as input and update the first model in-place.
+            device: Device that stores the averaged model. If ``None``, the
+                current model device is used.
+            decay: Decay factor for the exponential moving average. Should be between
+                0 and 1. Default is 0.999.
+            **kwargs: Additional arguments forwarded to
+                ``lightning.pytorch.callbacks.WeightAveraging``. ``use_buffers``
+                is always fixed to ``False`` in this subclass.
+        """
+
+        super().__init__(device, avg_fn=get_ema_avg_fn(decay), **kwargs)  # type: ignore[no-untyped-call]

--- a/aiaccel/torch/lightning/callbacks/no_buffer_weight_averaging.py
+++ b/aiaccel/torch/lightning/callbacks/no_buffer_weight_averaging.py
@@ -96,11 +96,10 @@ class NoBufferEMAWeightAveraging(NoBufferWeightAveraging):
         """Initialize the callback.
 
         Args:
-                take two models as input and update the first model in-place.
             device: Device that stores the averaged model. If ``None``, the
                 current model device is used.
-            decay: Decay factor for the exponential moving average. Should be between
-                0 and 1. Default is 0.999.
+            decay: Decay factor for the exponential moving average. Should be
+                between 0 and 1. Default is 0.999.
             **kwargs: Additional arguments forwarded to
                 ``lightning.pytorch.callbacks.WeightAveraging``. ``use_buffers``
                 is always fixed to ``False`` in this subclass.

--- a/aiaccel/torch/lightning/callbacks/no_buffer_weight_averaging.py
+++ b/aiaccel/torch/lightning/callbacks/no_buffer_weight_averaging.py
@@ -4,40 +4,15 @@
 from typing import Any
 
 import torch
-from torch.optim.swa_utils import get_ema_avg_fn
 
 from lightning.pytorch import LightningModule
-from lightning.pytorch.callbacks import WeightAveraging
+from lightning.pytorch.callbacks import EMAWeightAveraging, WeightAveraging
 
 
-class NoBufferWeightAveraging(WeightAveraging):
-    """Weight averaging callback that ignores buffers during averaging and swapping.
+class _NoBufferWeightAveragingMixin:
+    """Shared behavior for weight averaging callbacks that must ignore buffers."""
 
-    Checkpoints still store the current model buffers together with the averaged
-    parameters so loading preserves non-averaged buffer state.
-
-    Example:
-        >>> from lightning.pytorch import Trainer
-        >>> from torch.optim.swa_utils import get_ema_avg_fn
-        >>> ema = NoBufferWeightAveraging(avg_fn=get_ema_avg_fn(0.999))
-        >>> trainer = Trainer(callbacks=[ema])
-    """
-
-    def __init__(
-        self,
-        device: torch.device | str | int | None = None,
-        **kwargs: Any,
-    ):
-        """Initialize the callback.
-
-        Args:
-            device: Device that stores the averaged model. If ``None``, the
-                current model device is used.
-            **kwargs: Additional arguments forwarded to
-                ``lightning.pytorch.callbacks.WeightAveraging``. ``use_buffers``
-                is always fixed to ``False`` in this subclass.
-        """
-        super().__init__(device, use_buffers=False, **kwargs)
+    _average_model: Any | None
 
     def _swap_models(self, pl_module: LightningModule) -> None:
         assert self._average_model is not None
@@ -67,7 +42,7 @@ class NoBufferWeightAveraging(WeightAveraging):
         pl_module: LightningModule,
         checkpoint: dict[str, Any],
     ) -> None:
-        super().on_save_checkpoint(trainer, pl_module, checkpoint)
+        super().on_save_checkpoint(trainer, pl_module, checkpoint)  # type: ignore[misc]
 
         if self._average_model is None:
             return
@@ -84,26 +59,68 @@ class NoBufferWeightAveraging(WeightAveraging):
                 average_model_state[buffer_name] = current_model_state[buffer_name].clone()
 
 
-class NoBufferEMAWeightAveraging(NoBufferWeightAveraging):
-    """Exponential moving average (EMA) version of ``NoBufferWeightAveraging``."""
+class NoBufferWeightAveraging(_NoBufferWeightAveragingMixin, WeightAveraging):
+    """Weight averaging callback that ignores buffers during averaging and swapping.
+
+    Checkpoints still store the current model buffers together with the averaged
+    parameters so loading preserves non-averaged buffer state.
+
+    Example:
+        >>> from lightning.pytorch import Trainer
+        >>> from torch.optim.swa_utils import get_ema_avg_fn
+        >>> ema = NoBufferWeightAveraging(avg_fn=get_ema_avg_fn(0.999))
+        >>> trainer = Trainer(callbacks=[ema])
+    """
 
     def __init__(
         self,
         device: torch.device | str | int | None = None,
-        decay: float = 0.999,
         **kwargs: Any,
     ):
         """Initialize the callback.
 
         Args:
-                take two models as input and update the first model in-place.
             device: Device that stores the averaged model. If ``None``, the
                 current model device is used.
-            decay: Decay factor for the exponential moving average. Should be between
-                0 and 1. Default is 0.999.
             **kwargs: Additional arguments forwarded to
                 ``lightning.pytorch.callbacks.WeightAveraging``. ``use_buffers``
                 is always fixed to ``False`` in this subclass.
         """
+        super().__init__(device, use_buffers=False, **kwargs)
 
-        super().__init__(device, avg_fn=get_ema_avg_fn(decay), **kwargs)  # type: ignore[no-untyped-call]
+
+class NoBufferEMAWeightAveraging(_NoBufferWeightAveragingMixin, EMAWeightAveraging):
+    """Exponential moving average (EMA) callback that ignores buffers."""
+
+    def __init__(
+        self,
+        device: torch.device | str | int | None = None,
+        decay: float = 0.999,
+        update_every_n_steps: int = 1,
+        update_starting_at_step: int | None = None,
+        update_starting_at_epoch: int | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize the callback.
+
+        Args:
+            device: Device that stores the averaged model. If ``None``, the
+                current model device is used.
+            decay: Decay factor for the exponential moving average. Should be between
+                0 and 1. Default is 0.999.
+            update_every_n_steps: Update EMA every N optimizer steps.
+            update_starting_at_step: Start EMA updates at or after this optimizer step.
+            update_starting_at_epoch: Start EMA updates at or after this epoch.
+            **kwargs: Additional arguments forwarded to
+                ``lightning.pytorch.callbacks.EMAWeightAveraging``. ``use_buffers``
+                is always fixed to ``False`` in this subclass.
+        """
+        super().__init__(
+            device=device,
+            use_buffers=False,
+            decay=decay,
+            update_every_n_steps=update_every_n_steps,
+            update_starting_at_step=update_starting_at_step,
+            update_starting_at_epoch=update_starting_at_epoch,
+            **kwargs,
+        )

--- a/docs/source/api_reference/torch.rst
+++ b/docs/source/api_reference/torch.rst
@@ -87,6 +87,8 @@ Lightning Callbacks
 
     SaveMetricCallback
     LoadPretrainedCallback
+    NoBufferWeightAveraging
+    NoBufferEMAWeightAveraging
     PrintUnusedParam
 
 ****************


### PR DESCRIPTION
This pull request introduces two new callbacks for PyTorch Lightning that perform weight averaging while explicitly ignoring model buffers. These callbacks are now available for import and use, providing more control over how weight averaging is handled during training and checkpointing.

**New Weight Averaging Callbacks:**

* Added `NoBufferWeightAveraging` and `NoBufferEMAWeightAveraging` callbacks, which subclass Lightning's `WeightAveraging` but always ignore buffers during averaging and swapping. This ensures that only parameters are averaged, while buffers (such as running statistics in batch normalization) are preserved from the current model. (`aiaccel/torch/lightning/callbacks/no_buffer_weight_averaging.py`)
* Updated the `__init__.py` file to expose the new callbacks in the public API, making them available for import from the `aiaccel.torch.lightning.callbacks` package. (`aiaccel/torch/lightning/callbacks/__init__.py`)