### PR TITLE
Add fit_args and remove default last.ckpt

### DIFF
--- a/aiaccel/torch/apps/train.py
+++ b/aiaccel/torch/apps/train.py
@@ -1,12 +1,14 @@
 # Copyright (C) 2025 National Institute of Advanced Industrial Science and Technology (AIST)
 # SPDX-License-Identifier: MIT
 
-from typing import Any, cast
+
+from typing import cast
 
 from argparse import ArgumentParser
 import logging
 
 from hydra.utils import instantiate
+from omegaconf import DictConfig
 from omegaconf import OmegaConf as oc  # noqa: N813
 
 import lightning as lt
@@ -26,12 +28,15 @@ def main() -> None:
     args, unk_args = parser.parse_known_args()
 
     is_rank_zero = get_rank() == 0
-    config = prepare_config(
-        config_filename=args.config,
-        overwrite_config=oc.from_cli(unk_args),
-        print_config=is_rank_zero,
-        save_config=is_rank_zero,
-        save_filename="merged_config.yaml",
+    config = cast(
+        DictConfig,
+        prepare_config(
+            config_filename=args.config,
+            overwrite_config=oc.from_cli(unk_args),
+            print_config=is_rank_zero,
+            save_config=is_rank_zero,
+            save_filename="merged_config.yaml",
+        ),
     )
 
     if is_rank_zero:
@@ -48,7 +53,7 @@ def main() -> None:
     trainer.fit(
         model=instantiate(config.task),
         datamodule=instantiate(config.datamodule),
-        **cast(dict[str, Any], config.get("fit_args", {})),
+        **config.get("fit_args", {}),
     )
 
 

--- a/aiaccel/torch/apps/train.py
+++ b/aiaccel/torch/apps/train.py
@@ -46,6 +46,7 @@ def main() -> None:
     trainer.fit(
         model=instantiate(config.task),
         datamodule=instantiate(config.datamodule),
+        **config.get("fit_args", {}),
     )
 
 

--- a/aiaccel/torch/apps/train.py
+++ b/aiaccel/torch/apps/train.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2025 National Institute of Advanced Industrial Science and Technology (AIST)
 # SPDX-License-Identifier: MIT
 
+from typing import Any, cast
+
 from argparse import ArgumentParser
 import logging
 
@@ -46,7 +48,7 @@ def main() -> None:
     trainer.fit(
         model=instantiate(config.task),
         datamodule=instantiate(config.datamodule),
-        **config.get("fit_args", {}),
+        **cast(dict[str, Any], config.get("fit_args", {})),
     )
 
 

--- a/aiaccel/torch/apps/train.py
+++ b/aiaccel/torch/apps/train.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 
-from typing import cast
-
 from argparse import ArgumentParser
 import logging
 
@@ -28,16 +26,14 @@ def main() -> None:
     args, unk_args = parser.parse_known_args()
 
     is_rank_zero = get_rank() == 0
-    config = cast(
-        DictConfig,
-        prepare_config(
-            config_filename=args.config,
-            overwrite_config=oc.from_cli(unk_args),
-            print_config=is_rank_zero,
-            save_config=is_rank_zero,
-            save_filename="merged_config.yaml",
-        ),
+    config = prepare_config(
+        config_filename=args.config,
+        overwrite_config=oc.from_cli(unk_args),
+        print_config=is_rank_zero,
+        save_config=is_rank_zero,
+        save_filename="merged_config.yaml",
     )
+    assert isinstance(config, DictConfig)
 
     if is_rank_zero:
         status_list = collect_git_status_from_config(config)

--- a/aiaccel/torch/lightning/ckpt.py
+++ b/aiaccel/torch/lightning/ckpt.py
@@ -54,8 +54,7 @@ def load_checkpoint(
     config_path = model_path / config_name
     config = prepare_config(config_path, overwrite_config=overwrite_config)
 
-    checkpoint_filename = config.checkpoint_filename if "checkpoint_filename" in config else "last.ckpt"
-    checkpoint_path = model_path / "checkpoints" / checkpoint_filename
+    checkpoint_path = model_path / "checkpoints" / config.checkpoint_filename
 
     logger.info(f"Loading model from {checkpoint_path}...")
 


### PR DESCRIPTION
This pull request introduces minor but important improvements to the training and checkpoint loading processes in the `aiaccel/torch` package. The changes enhance flexibility in training configuration and simplify checkpoint path resolution.

**Training configuration flexibility:**

* In `aiaccel/torch/apps/train.py`, the `trainer.fit` call now unpacks any additional arguments provided in the `fit_args` section of the configuration, allowing for more customizable training runs.

**Checkpoint loading simplification:**

* In `aiaccel/torch/lightning/ckpt.py`, the checkpoint loading logic now directly uses `config.checkpoint_filename` for the checkpoint path, removing the previous conditional and default fallback, which streamlines the code and reduces ambiguity.