### PR TITLE
Fix WARNING building documents.

### DIFF
--- a/aiaccel/job/utils/split_tasks.py
+++ b/aiaccel/job/utils/split_tasks.py
@@ -7,6 +7,19 @@ import os
 
 
 def split_tasks(task_list: list[Any]) -> list[Any]:
+    """
+    Return the task shard assigned to the current array job.
+
+    This function uses ``TASK_INDEX`` and ``TASK_STEPSIZE`` from the environment to
+    slice ``task_list``. The start position is computed as ``TASK_INDEX - 1``.
+    If ``TASK_INDEX`` is not defined, an empty list is returned.
+
+    Args:
+        task_list (list[Any]): Full list of tasks to be split across array jobs.
+
+    Returns:
+        list[Any]: Tasks assigned to the current array job.
+    """
     if "TASK_INDEX" in os.environ:
         start = int(os.environ["TASK_INDEX"]) - 1
         end = start + int(os.environ["TASK_STEPSIZE"])

--- a/aiaccel/torch/lr_schedulers/sequential_lr.py
+++ b/aiaccel/torch/lr_schedulers/sequential_lr.py
@@ -8,30 +8,36 @@ import torch
 
 class SequentialLR(torch.optim.lr_scheduler.SequentialLR):
     """
-    A wrapper of torch.optim.lr_scheduler.SequentialLR to use list of functions
-    to create schedulers.
+    Build a sequential learning rate scheduler from scheduler factory functions.
+
+    This wrapper makes it easier to define multiple schedulers in Hydra or
+    OmegaConf-based configurations, where each entry in ``schedulers_fn`` is a
+    partially configured callable that receives ``optimizer`` and returns a
+    scheduler instance.
 
     Args:
-        optimizer: Optimizer.
-        schedulers_fn: List of functions to create schedulers.
-        milestones: List of epoch indices. Must be increasing.
+        optimizer (torch.optim.Optimizer): Optimizer passed to each scheduler factory.
+        schedulers_fn (list[Callable[[torch.optim.Optimizer], torch.optim.lr_scheduler._LRScheduler]]):
+            Factory functions that create schedulers for ``optimizer``.
+        milestones (list[int]): Epoch indices at which to switch to the next scheduler.
 
-    ... code-block:: yaml
+    Example:
+        .. code-block:: yaml
 
-        scheduler_generator:
-          _partial_: True
-          _convert_: "all"
-          _target_: aiaccel.lr_schedulers.SequentialLR
-          schedulers_fn:
-            - _target_: torch.optim.lr_scheduler.LinearLR
+            scheduler_generator:
               _partial_: True
-              start_factor: 1.e-3
-              end_factor: 1.0
-              total_iters: 5000
-            - _target_: torch.optim.lr_scheduler.CosineAnnealingLR
-            _partial_: True
-            T_max: 95000
-          milestones: [5000]
+              _convert_: all
+              _target_: aiaccel.torch.lr_schedulers.SequentialLR
+              schedulers_fn:
+                - _target_: torch.optim.lr_scheduler.LinearLR
+                  _partial_: True
+                  start_factor: 1.0e-3
+                  end_factor: 1.0
+                  total_iters: 5000
+                - _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+                  _partial_: True
+                  T_max: 95000
+              milestones: [5000]
     """
 
     def __init__(

--- a/docs/source/api_reference/hpo.rst
+++ b/docs/source/api_reference/hpo.rst
@@ -11,7 +11,7 @@
 .. autosummary::
     :toctree: generated/
 
-    NelderMeadAlgorism
+    NelderMeadAlgorithm
 
 ******************
  Optuna Utilities

--- a/docs/source/api_reference/job.rst
+++ b/docs/source/api_reference/job.rst
@@ -7,4 +7,4 @@
 .. autosummary::
     :toctree: generated/
 
-    slice_tasks
+    split_tasks

--- a/docs/source/api_reference/job.rst
+++ b/docs/source/api_reference/job.rst
@@ -2,7 +2,7 @@
  Job Utilities
 ###############
 
-.. currentmodule:: aiaccel.job
+.. currentmodule:: aiaccel.job.utils
 
 .. autosummary::
     :toctree: generated/

--- a/docs/source/user_guide/hpo.rst
+++ b/docs/source/user_guide/hpo.rst
@@ -215,8 +215,8 @@ the dedicated documentation for usage details and configuration options.
 
 - :doc:`config` - complete reference for Hydra-style YAML composition used by
   ``aiaccel-hpo``.
-- :doc:`job` - explains how payload commands are embedded in templates, which
-  mirrors the ``command`` handling in the optimizer.
+- :doc:`job` - explains how payload commands are embedded in templates, which mirrors
+  the ``command`` handling in the optimizer.
 - ``examples/hpo`` - runnable Optuna examples, including Nelder-Mead flows and COCO
   benchmarks.
 - Optuna documentation - visualization utilities, sampler details, and storage backends

--- a/docs/source/user_guide/hpo.rst
+++ b/docs/source/user_guide/hpo.rst
@@ -213,9 +213,9 @@ the dedicated documentation for usage details and configuration options.
  Further Reading
 *****************
 
-- :doc:`user_guide/config` - complete reference for Hydra-style YAML composition used by
+- :doc:`config` - complete reference for Hydra-style YAML composition used by
   ``aiaccel-hpo``.
-- :doc:`user_guide/job` - explains how payload commands are embedded in templates, which
+- :doc:`job` - explains how payload commands are embedded in templates, which
   mirrors the ``command`` handling in the optimizer.
 - ``examples/hpo`` - runnable Optuna examples, including Nelder-Mead flows and COCO
   benchmarks.

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -8,7 +8,7 @@ python -m pip install aiaccel
 
 ## Tutorials
 When you want to try the tutorials, we recommend setting up the environment with `pixi`, which installs aiaccel together with every required dependency.
-First, install `pixi` by following the instructions at: [https://pixi.sh/latest/installation/]()
+First, install `pixi` by following the instructions at [pixi installation guide](https://pixi.sh/latest/installation/).
 
 ```bash
 git clone https://github.com/aistairc/aiaccel.git


### PR DESCRIPTION
ドキュメント生成時の WARNING を解消しました

- NelderMeadAlgoriths の typo を修正しました
- `slice_tasks` は `aiaccel/job/utils/split_tasks.py` を指しているものと判断し、 `split_tasks` に修正しました
  - 併せて `split_tasks` の docstring を追加しました
- `docs/build/html/index.html` の pixi インストールガイドのリンクを修正しました
- `aiaccel/torch/lr_schedulers/sequential_lr.py` の docstring を整形しました