### PR TITLE
Fix link text position in docs.

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,4 @@
+dt a.reference.external:has(.viewcode-link)::before{
+    content: "\a ";
+    white-space: pre;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,7 @@ html_show_sourcelink = False
 html_show_sphinx = False
 
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 html_theme_options = {
     "accent_color": "gold",
     "nav_links": [


### PR DESCRIPTION
ドキュメント内の github へのリンクテキスト(`[source]`)位置の仕様を `sphinx.ext.viewcode` のものと同じになるように改修しました。

改修前
<img width="941" height="353" alt="Screenshot from 2026-04-28 09-43-36" src="https://github.com/user-attachments/assets/8f272404-9d37-4165-8bee-bd45c9b6e1b5" />

改修後
<img width="961" height="399" alt="Screenshot from 2026-04-28 14-58-34" src="https://github.com/user-attachments/assets/d01cf427-b04f-4312-aba8-97441679af72" />
