### PR TITLE
Set the hpcx version to 2.20.

### DIFF
--- a/aiaccel/job/apps/config/pbs.yaml
+++ b/aiaccel/job/apps/config/pbs.yaml
@@ -34,7 +34,7 @@ mpi:
     -q rt_HF -l select={args.n_nodes}:mpiprocs=$(( {args.n_procs} / {args.n_nodes} )):ompthreads=$(( {args.n_nodes} * 96 / {args.n_procs} ))
   job: |
     source /etc/profile.d/modules.sh
-    module load hpcx
+    module load hpcx/2.20
 
     mpirun -np {args.n_procs} -bind-to none -map-by slot \\
         -mca pml ob1 -mca btl self,tcp -mca btl_tcp_if_include bond0 \\
@@ -45,7 +45,7 @@ train:
     -q $( (({args.n_gpus}==1)) && printf rt_HG || printf rt_HF ) -l select=$(( ({args.n_gpus} + 7) / 8 )):mpiprocs=$( (({args.n_gpus}==1)) && printf 1 || printf 8 ):ompthreads=$( (({args.n_gpus}==1)) && printf 8 || printf 12 )
   job: |
     source /etc/profile.d/modules.sh
-    module load hpcx
+    module load hpcx/2.20
 
     mpirun -np {args.n_gpus} -bind-to none -map-by slot \\
         -mca pml ob1 -mca btl self,tcp -mca btl_tcp_if_include bond0 \\


### PR DESCRIPTION
ABCI3.0 での `module load hpcx` のデフォルトバージョンが 2.26 になっており、
その影響で mpirun のオプション `-bind-to none -map-by slot` が認識できずエラーが発生したので、
暫定で hpcx のバージョンを 2.20 に固定する改修を行いました。