### PR TITLE
Fix check git

### DIFF
--- a/aiaccel/config/apps/check_git.py
+++ b/aiaccel/config/apps/check_git.py
@@ -16,7 +16,10 @@ def main() -> None:
     args, unk_args = parser.parse_known_args()
     config = prepare_config(args.config, overwrite_config=oc.from_cli(unk_args))
 
-    if len(git_status := collect_git_status_from_config(config)) > 0:
+    git_status = collect_git_status_from_config(config)
+    not_ready_status = [status for status in git_status if not status.ready()]
+
+    if len(not_ready_status) > 0:
         print_git_status(git_status)
 
         exit(1)

--- a/aiaccel/config/apps/check_git.py
+++ b/aiaccel/config/apps/check_git.py
@@ -17,11 +17,10 @@ def main() -> None:
     config = prepare_config(args.config, overwrite_config=oc.from_cli(unk_args))
 
     git_status = collect_git_status_from_config(config)
-    not_ready_status = [status for status in git_status if not status.ready()]
 
-    if len(not_ready_status) > 0:
-        print_git_status(git_status)
+    print_git_status(git_status)
 
+    if len([status for status in git_status if not status.ready()]) > 0:
         exit(1)
     else:
         exit(0)

--- a/tests/config/apps/test_check_git.py
+++ b/tests/config/apps/test_check_git.py
@@ -28,7 +28,7 @@ def test_check_git(mocker: MockerFixture) -> None:
 
     # Failed
     mock_func = mocker.patch("aiaccel.config.apps.check_git.collect_git_status_from_config")
-    mock_func.return_value = [PackageGitStatus("test_package", "test_id", [])]
+    mock_func.return_value = [PackageGitStatus("test_package", "test_id", ["aiaccel/test"])]
 
     try:
         check_git.main()

--- a/tests/config/apps/test_check_git.py
+++ b/tests/config/apps/test_check_git.py
@@ -18,7 +18,7 @@ def test_check_git(mocker: MockerFixture) -> None:
 
     # Success
     mock_func = mocker.patch("aiaccel.config.apps.check_git.collect_git_status_from_config")
-    mock_func.return_value = []
+    mock_func.return_value = [PackageGitStatus("test_package", "test_id", [])]
 
     try:
         check_git.main()
@@ -28,7 +28,7 @@ def test_check_git(mocker: MockerFixture) -> None:
 
     # Failed
     mock_func = mocker.patch("aiaccel.config.apps.check_git.collect_git_status_from_config")
-    mock_func.return_value = [PackageGitStatus("test_package", "test_id", ["aiaccel/test"])]
+    mock_func.return_value = [PackageGitStatus("test_package", "test_id", ["test_package/test"])]
 
     try:
         check_git.main()


### PR DESCRIPTION
aiaccel-config check-git で差分が出ていない場合にも exit 1 が発生する現象を修正しました